### PR TITLE
Improve speed of detection for annotated frames

### DIFF
--- a/octron/main.py
+++ b/octron/main.py
@@ -63,6 +63,8 @@ import zarr
 from octron.sam_octron.helpers.sam2_zarr import (
     create_image_zarr,
     load_image_zarr,
+    get_annotated_frames,
+    mark_frames_annotated,
 )
 # YOLO specific 
 from octron.yolo_octron.gui.yolo_handler import YoloHandler
@@ -648,6 +650,12 @@ class octron_widget(QWidget):
             # Also write to layer immediately so the viewer shows the
             # masks while the current frame is still on screen.
             prediction_layer.data[frame_idx, :, :] = current
+            # Track annotated frames (batched flush in _on_prediction_finished)
+            pending = getattr(self, '_pending_annotated_frames', {})
+            key = id(prediction_layer.data)
+            pending.setdefault(key, (prediction_layer.data, set()))
+            pending[key][1].add(int(frame_idx))
+            self._pending_annotated_frames = pending
             prediction_layer.refresh()
         else:
             # Flush any pending semantic buffer before handling non-semantic object
@@ -656,6 +664,12 @@ class octron_widget(QWidget):
             organizer_entry = self.object_organizer.get_entry(obj_id)
             prediction_layer = organizer_entry.prediction_layer
             prediction_layer.data[frame_idx,:,:] = mask
+            # Track annotated frames (batched flush in _on_prediction_finished)
+            pending = getattr(self, '_pending_annotated_frames', {})
+            key = id(prediction_layer.data)
+            pending.setdefault(key, (prediction_layer.data, set()))
+            pending[key][1].add(int(frame_idx))
+            self._pending_annotated_frames = pending
             prediction_layer.refresh()
         
         if self._viewer.dims.current_step[0] != frame_idx and not last_run:
@@ -670,6 +684,11 @@ class octron_widget(QWidget):
         """
         # Flush the last semantic frame buffer (propagation ended)
         self._flush_semantic_frame_buffer()
+        
+        # Batch-flush all pending annotated frame attrs accumulated during propagation
+        for zarr_array, frame_set in getattr(self, '_pending_annotated_frames', {}).values():
+            mark_frames_annotated(zarr_array, frame_set)
+        self._pending_annotated_frames = {}
         
         # Enable the predcition button again
         self.predict_next_batch_btn.setEnabled(True)
@@ -1837,7 +1856,7 @@ class octron_widget(QWidget):
         indices = []
         for layer in prediction_layers:
             data = layer.data
-            annotated_indices = np.where(data[:,0,0] >= 0)[0]
+            annotated_indices = get_annotated_frames(data)
             # Get the next index after the current one
             next_idx = np.where(annotated_indices > current_timeline_idx)[0]
             if next_idx.size > 0:
@@ -1865,7 +1884,7 @@ class octron_widget(QWidget):
         indices = []
         for layer in prediction_layers:
             data = layer.data
-            annotated_indices = np.where(data[:,0,0] >= 0)[0]
+            annotated_indices = get_annotated_frames(data)
             # Get the next index after the current one
             prev_idx = np.where(annotated_indices < current_timeline_idx)[0]
             if prev_idx.size > 0:

--- a/octron/sam_octron/helpers/sam2_layer.py
+++ b/octron/sam_octron/helpers/sam2_layer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 from napari.utils import Colormap
 from napari.utils.notifications import show_info, show_error
-from octron.sam_octron.helpers.sam2_zarr import create_image_zarr, load_image_zarr
+from octron.sam_octron.helpers.sam2_zarr import create_image_zarr, load_image_zarr, get_annotated_frames
 import warnings 
 warnings.simplefilter("ignore")
 
@@ -269,8 +269,8 @@ def add_annotation_projection(
         colors = label_colors[indices_max_diff_labels[entry.label_id % object_organizer.n_labels_max]]
         colors.insert(0, [0.,0.,0.,0.]) # Add transparent color for background
         cm = Colormap(colors, name=label, display_name=label)
-        # Filter by prediction indices. The fill value is -1, so we can filter by >= 0
-        predicted_indices = np.where(prediction_layer_data[:,0,0] >= 0)[0]
+        # Filter by prediction indices (fast path via zarr attribute)
+        predicted_indices = get_annotated_frames(prediction_layer_data)
         if len(predicted_indices):
             prediction_layer_data = prediction_layer_data[predicted_indices]
             collected_mask_data.append(prediction_layer_data)

--- a/octron/sam_octron/helpers/sam2_layer_callback.py
+++ b/octron/sam_octron/helpers/sam2_layer_callback.py
@@ -8,6 +8,7 @@ from octron.sam_octron.helpers.sam2_octron import (
     run_new_pred,
 )
 from octron.sam_octron.helpers.sam2_colors import sample_maximally_different, create_semantic_colormap
+from octron.sam_octron.helpers.sam2_zarr import mark_frames_annotated
 from napari.utils.notifications import (
     show_warning,
     show_info,
@@ -150,6 +151,7 @@ class sam2_octron_callbacks():
                 # for the SAM2-HQ model. See comments in 
                 # sam2hq_octron.add_new_mask / add_new_points_or_box
                 prediction_layer.data[frame_idx] = mask
+                mark_frames_annotated(prediction_layer.data, frame_idx)
                 prediction_layer.refresh()
   
         else:
@@ -277,6 +279,7 @@ class sam2_octron_callbacks():
         
         # Update visual layer
         prediction_layer.data[frame_idx] = id_mask
+        mark_frames_annotated(prediction_layer.data, frame_idx)
         
         # Assign distinct colors so each object ID is visually separable
         prediction_layer.colormap = create_semantic_colormap(n_objects, label_id=organizer_entry.label_id)
@@ -390,6 +393,7 @@ class sam2_octron_callbacks():
                     # for the SAM2-HQ model. See comments in 
                     # sam2hq_octron.add_new_mask / add_new_points_or_box
                     prediction_layer.data[frame_idx,:,:] = mask
+                    mark_frames_annotated(prediction_layer.data, frame_idx)
             prediction_layer.refresh()  
         else:
             # Catching all above with ['added','removed','changed']

--- a/octron/sam_octron/helpers/sam2_zarr.py
+++ b/octron/sam_octron/helpers/sam2_zarr.py
@@ -18,6 +18,91 @@ MIN_ZARR_CHUNK_SIZE = 50 # Setting minimum chunk size for zarr arrays
                          # to avoid excessive chunking for small arrays
 
 
+
+
+def get_annotated_frames(zarr_array):
+    """
+    Return a sorted numpy array of frame indices that have been annotated.
+    
+    Reads the 'annotated_frames' zarr attribute if present; otherwise
+    falls back to scanning zarr_array[:,0,0] >= 0 (for old zarr files
+    created before this attribute existed) and attempts to migrate the
+    attribute for future fast access.
+    
+    Comment Horst: 
+    # These replace the old pattern of scanning zarr_array[:,0,0] >= 0 to find
+    # which frames have been annotated.  The frame indices are now stored in a
+    # small JSON attribute ('annotated_frames') on each zarr array, which is
+    # essentially instant to read.
+    
+    Parameters
+    ----------
+    zarr_array : zarr.core.Array
+        The zarr array (mask / prediction data).
+        
+    Returns
+    -------
+    annotated : np.ndarray
+        Sorted 1-D int array of annotated frame indices.
+    """
+    if hasattr(zarr_array, 'attrs'):
+        frames = zarr_array.attrs.get('annotated_frames', None)
+        if frames is not None:
+            return np.array(frames, dtype=int)
+    # Fallback: scan data (old zarr without the attribute)
+    annotated = np.where(zarr_array[:, 0, 0] >= 0)[0]
+    # Attempt one-time migration
+    try:
+        if hasattr(zarr_array, 'attrs'):
+            zarr_array.attrs['annotated_frames'] = annotated.tolist()
+    except Exception:
+        pass  # read-only store — skip silently
+    return annotated
+
+
+def mark_frames_annotated(zarr_array, frame_indices):
+    """
+    Add one or more frame indices to the 'annotated_frames' attribute.
+    
+    Parameters
+    ----------
+    zarr_array : zarr.core.Array
+        The zarr array whose attribute should be updated.
+    frame_indices : int, np.integer, or iterable of int
+        Frame index or indices to mark as annotated.
+    """
+    if not hasattr(zarr_array, 'attrs'):
+        return
+    existing = set(zarr_array.attrs.get('annotated_frames', []))
+    if isinstance(frame_indices, (int, np.integer)):
+        existing.add(int(frame_indices))
+    else:
+        existing.update(int(f) for f in frame_indices)
+    zarr_array.attrs['annotated_frames'] = sorted(existing)
+
+
+def unmark_frames_annotated(zarr_array, frame_indices):
+    """
+    Remove one or more frame indices from the 'annotated_frames' attribute.
+    
+    Parameters
+    ----------
+    zarr_array : zarr.core.Array
+        The zarr array whose attribute should be updated.
+    frame_indices : int, np.integer, or iterable of int
+        Frame index or indices to remove.
+    """
+    if not hasattr(zarr_array, 'attrs'):
+        return
+    existing = set(zarr_array.attrs.get('annotated_frames', []))
+    if isinstance(frame_indices, (int, np.integer)):
+        existing.discard(int(frame_indices))
+    else:
+        for f in frame_indices:
+            existing.discard(int(f))
+    zarr_array.attrs['annotated_frames'] = sorted(existing)
+
+
 def create_image_zarr(zarr_path, 
                       num_frames, 
                       image_height,
@@ -103,6 +188,7 @@ def create_image_zarr(zarr_path,
                                     )
     image_zarr.attrs['created_at'] = str(datetime.now())
     image_zarr.attrs['video_hash'] = video_hash_abbrev
+    image_zarr.attrs['annotated_frames'] = []
     if verbose:
         print('Zarr store info:')
         print(image_zarr.info)
@@ -195,6 +281,13 @@ def load_image_zarr(zarr_path,
         elif verbose:
             print(f"🔒 Video hash verified: {video_hash_abrrev}")
     
+    # One-time migration: populate annotated_frames attr for old zarr files
+    if image_zarr.attrs.get('annotated_frames', None) is None:
+        migrated = np.where(image_zarr[:, 0, 0] >= 0)[0]
+        image_zarr.attrs['annotated_frames'] = migrated.tolist()
+        if verbose:
+            print(f"Migrated annotated_frames attribute ({len(migrated)} frames)")
+
     if verbose:
         print('Zarr store info:')
         print(image_zarr.info) 

--- a/octron/sam_octron/object_organizer.py
+++ b/octron/sam_octron/object_organizer.py
@@ -3,6 +3,7 @@ from shutil import rmtree
 import json
 import datetime
 import numpy as np
+from octron.sam_octron.helpers.sam2_zarr import get_annotated_frames
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import Optional, Union, Dict, List, Any
 
@@ -287,7 +288,7 @@ class ObjectOrganizer(BaseModel):
             if obj.prediction_layer is not None:
                 prediction_layer_data = obj.prediction_layer.data
                 prediction_layer_meta = obj.prediction_layer.metadata
-                predicted_indices = np.where(prediction_layer_data[:,0,0] >= 0)[0]
+                predicted_indices = get_annotated_frames(prediction_layer_data)
                 if len(predicted_indices):
                     num_predicted_indices = len(predicted_indices)
                 else:

--- a/octron/yolo_octron/helpers/sam2_results.py
+++ b/octron/yolo_octron/helpers/sam2_results.py
@@ -9,6 +9,7 @@ from scipy.ndimage import gaussian_filter1d
 from skimage.morphology import remove_small_holes, binary_closing, disk
 from tqdm import tqdm
 from skimage.measure import regionprops
+from octron.sam_octron.helpers.sam2_zarr import get_annotated_frames
 
 class ANNOT_results:
     def __init__(self, annotation_dir, verbose=True, **kwargs):
@@ -111,7 +112,7 @@ class ANNOT_results:
                 if self.verbose:
                     print(f"Extracted video dimensions from zarr: {self.num_frames} frames, {self.width}x{self.height}")
             # Check which indices are empty 
-            self.frame_indices_dict[label_name] = np.where(self.zarr_dict[label_name][:,0,0] != -1)[0]
+            self.frame_indices_dict[label_name] = get_annotated_frames(self.zarr_dict[label_name])
     
     
     def create_tracking_dict(self):

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -184,7 +184,7 @@ def collect_labels(project_path,
     # Hiding some imports here to reduce initial loading time
     from napari_pyav._reader import FastVideoReader
     from octron.sam_octron.helpers.video_loader import get_vfile_hash
-    from octron.sam_octron.helpers.sam2_zarr import load_image_zarr   
+    from octron.sam_octron.helpers.sam2_zarr import load_image_zarr, get_annotated_frames
 
     project_path = Path(project_path)
     assert project_path.exists(), f'Project path not found at {project_path.as_posix()}'
@@ -263,9 +263,8 @@ def collect_labels(project_path,
             assert image_height == loaded_masks.shape[1]
             assert image_width  == loaded_masks.shape[2]
             labels[label_id]['masks'].append(loaded_masks) # This is the zarr array
-            # Extract annotated frame indices
-            # The fill value of the zarr array is -1, so we can use this to find annotated frames
-            annotated_indices = np.where(loaded_masks[:,0,0] >= 0)[0]
+            # Extract annotated frame indices from zarr attribute (fast path)
+            annotated_indices = get_annotated_frames(loaded_masks)
             if verbose:
                 print(f'Found {len(annotated_indices)} annotated frames for label {label} in {object_organizer.parent.name}')
             # if prune_empty_labels:

--- a/octron/yolo_octron/helpers/yolo_results.py
+++ b/octron/yolo_octron/helpers/yolo_results.py
@@ -12,6 +12,7 @@ from napari.utils import DirectLabelColormap
 from scipy.ndimage import gaussian_filter1d
 from skimage.morphology import remove_small_holes, binary_closing, disk
 from tqdm import tqdm
+from octron.sam_octron.helpers.sam2_zarr import get_annotated_frames
 
 class YOLO_results:
     def __init__(self, results_dir, verbose=True, **kwargs):
@@ -729,9 +730,7 @@ class YOLO_results:
                         assert width == self.width, \
                             f"Width in mask data ({width}) does not match width in video ({self.width})."
                     # Find out which indices have data
-                    frame_indices = np.where(
-                        (masks[:,0,0] != -1) # -1 indicates no data for the frame
-                    )[0]
+                    frame_indices = get_annotated_frames(masks)
                     if len(frame_indices) == 0 and self.verbose: 
                         print(f"Warning: No valid frames found for track ID '{track_id}' (label '{label}') in mask data.")
                     if len(frame_indices) and close_holes: 

--- a/octron/yolo_octron/helpers/yolo_zarr.py
+++ b/octron/yolo_octron/helpers/yolo_zarr.py
@@ -92,6 +92,7 @@ def create_prediction_zarr(store,
                                    )
     image_zarr.attrs['created_at'] = str(datetime.now())
     image_zarr.attrs['video_hash'] = video_hash
+    image_zarr.attrs['annotated_frames'] = []
     if verbose:
         print('Zarr array info:')
         print(image_zarr.info)


### PR DESCRIPTION
Instead of checking the top left pixel of every frame for `> -1` (which is the default fill value for a zarr in OCTRON) I am now keeping track of annotated frames in an `attr` of the zarr array they belong to in a single array. This is much faster than checking the whole array, particularly for videos with high number of frames. This yields speedups throughout the GUI and its functions since every mask zarr array is affected. Particularly, loading and checking data (for example on the project manager table) is sped up a lot. The attrs themselves are saved in a singular location as json in the zarr array. 

The datatype of the zarr array is still `int16`, with theoretical space for 32,767 individual masks per layer.  This PR is backwards compatible with older annotation data and updates old annotation data upon first load. 

---
before

https://github.com/user-attachments/assets/3a4c42c2-1765-45a5-bf22-6e29363e02ca

---
after

https://github.com/user-attachments/assets/a93353e9-aa0b-4265-b3ba-9c6ecb89c15d


