### PR TITLE
Load cotracker3 model and expose in dropdown (1/6) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,9 @@ cython_debug/
 # model files (can be downloaded with shell script )
 *.pt 
 
+# Cotracker specific
+*.pth
+
 # Ignore zarr arrays 
 *.zarr*
 

--- a/octron/cotracker_octron/helpers/build_cotracker.py
+++ b/octron/cotracker_octron/helpers/build_cotracker.py
@@ -1,0 +1,53 @@
+"""
+
+Follow the pattern in build_sam3_octron.py:
+
+Load CoTracker3 checkpoint (from torch hub or local file)
+Move to device, set eval mode
+Return (model, device)
+
+
+cotracker = torch.hub.load("facebookresearch/co-tracker", "cotracker3_online").to(device)
+
+# Run Online CoTracker, the same model with a different API:
+# Initialize online processing
+cotracker(video_chunk=video, is_first_step=True, grid_size=grid_size)
+
+# Process the video
+for ind in range(0, video.shape[1] - cotracker.step, cotracker.step):
+    pred_tracks, pred_visibility = cotracker(
+        video_chunk=video[:, ind : ind + cotracker.step * 2]
+    )  # B T N 2,  B T N 1
+"""
+
+import torch
+from cotracker.predictor import CoTrackerOnlinePredictor
+
+
+def build_cotracker(ckpt_path):
+    """Build the CoTracker model from a checkpoint path.
+
+    It assumes the checkpoint is already downloaded and available at ckpt_path.
+    Returns the model and the torch device it's on.
+    """
+    # Find out which device to use
+    device = torch.device(
+        "cuda"
+        if torch.cuda.is_available()
+        else "mps"
+        if torch.backends.mps.is_available()
+        else "cpu"
+    )
+
+    # Get online CoTracker predictor and move to device
+    model = CoTrackerOnlinePredictor(checkpoint=ckpt_path)
+    model = model.to(device)
+
+    # Cotracker does not require the input image to be a certain
+    # size, but internally its working resolution is 384×512. It then
+    # scales the predicted tracks back to the original video resolution. 
+    # For the zarr cache we set it to the actual video resolution to match
+    # the napari videos and the cotracker results. 
+    model.image_size = None
+
+    return model, device

--- a/octron/cotracker_octron/helpers/build_cotracker.py
+++ b/octron/cotracker_octron/helpers/build_cotracker.py
@@ -17,7 +17,7 @@ def build_cotracker(ckpt_path):
         else "cpu"
     )
 
-    # Get online CoTracker predictor and move to device
+    # Instantiate CoTracker model from checkpoint and move to device
     model = CoTrackerOnlinePredictor(checkpoint=ckpt_path)
     model = model.to(device)
 

--- a/octron/cotracker_octron/helpers/build_cotracker.py
+++ b/octron/cotracker_octron/helpers/build_cotracker.py
@@ -1,25 +1,3 @@
-"""
-
-Follow the pattern in build_sam3_octron.py:
-
-Load CoTracker3 checkpoint (from torch hub or local file)
-Move to device, set eval mode
-Return (model, device)
-
-
-cotracker = torch.hub.load("facebookresearch/co-tracker", "cotracker3_online").to(device)
-
-# Run Online CoTracker, the same model with a different API:
-# Initialize online processing
-cotracker(video_chunk=video, is_first_step=True, grid_size=grid_size)
-
-# Process the video
-for ind in range(0, video.shape[1] - cotracker.step, cotracker.step):
-    pred_tracks, pred_visibility = cotracker(
-        video_chunk=video[:, ind : ind + cotracker.step * 2]
-    )  # B T N 2,  B T N 1
-"""
-
 import torch
 from cotracker.predictor import CoTrackerOnlinePredictor
 
@@ -30,7 +8,7 @@ def build_cotracker(ckpt_path):
     It assumes the checkpoint is already downloaded and available at ckpt_path.
     Returns the model and the torch device it's on.
     """
-    # Find out which device to use
+    # Select device
     device = torch.device(
         "cuda"
         if torch.cuda.is_available()

--- a/octron/cotracker_octron/helpers/cotracker_checks.py
+++ b/octron/cotracker_octron/helpers/cotracker_checks.py
@@ -1,4 +1,4 @@
-import os
+# Code for checking the availability of the Cotracker model checkpoint
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download
@@ -14,7 +14,9 @@ def download_cotracker_file(filename, local_dir, overwrite=False):
     Parameters
     ----------
     filename : str
-        Name of the file to download (e.g. "cotracker_scaled_online.pth", "config.json").
+        Name of the file to download from the HF repository at
+        https://huggingface.co/facebook/cotracker3/tree/main
+        (e.g. "scaled_online.pth").
     local_dir : str or Path
         Local directory to download into.
     overwrite : bool
@@ -66,7 +68,7 @@ def check_cotracker_models(checkpoints_dir, force_download=False):
     """
     checkpoints_dir = Path(checkpoints_dir)
     if not checkpoints_dir.exists():
-        os.makedirs(checkpoints_dir, exist_ok=True)
+        checkpoints_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         for fname in COTRACKER_FILES:

--- a/octron/cotracker_octron/helpers/cotracker_checks.py
+++ b/octron/cotracker_octron/helpers/cotracker_checks.py
@@ -47,7 +47,7 @@ def download_cotracker_file(filename, local_dir, overwrite=False):
 
 def check_cotracker_models(checkpoints_dir, force_download=False):
     """
-    Ensure the Cotracker checkpoint and config are available locally.
+    Ensure the Cotracker files are available locally.
     Downloads them from HuggingFace if missing.
 
     Returns a dictionary for the model-selection dropdown.
@@ -55,7 +55,7 @@ def check_cotracker_models(checkpoints_dir, force_download=False):
     Parameters
     ----------
     checkpoints_dir : str or Path
-        Directory where cotracker.pt and config.json should reside
+        Directory where the files should reside
         (typically ``<base_path>/cotracker_octron/checkpoints``).
     force_download : bool
         Re-download even if files exist.

--- a/octron/cotracker_octron/helpers/cotracker_checks.py
+++ b/octron/cotracker_octron/helpers/cotracker_checks.py
@@ -88,10 +88,13 @@ def check_cotracker_models(checkpoints_dir, force_download=False):
         return {}
 
     # Build the models dict (relative to cotracker_octron/)
+    ckpt_path_anchor = next(
+        p for p in ckpt_path.parents if p.name == "cotracker_octron"
+    )
     cotracker_models_dict = {
         "cotracker": {
             "name": "Cotracker3",
-            "checkpoint_path": "checkpoints/scaled_online.pth",
+            "checkpoint_path": ckpt_path.relative_to(ckpt_path_anchor).as_posix(),
         }
     }
     return cotracker_models_dict

--- a/octron/cotracker_octron/helpers/cotracker_checks.py
+++ b/octron/cotracker_octron/helpers/cotracker_checks.py
@@ -1,0 +1,95 @@
+import os
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download
+
+COTRACKER_HF_REPO = "facebook/cotracker3"
+COTRACKER_FILES = ["scaled_online.pth"]
+
+
+def download_cotracker_file(filename, local_dir, overwrite=False):
+    """
+    Download a single file from the Cotracker HuggingFace repository.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to download (e.g. "cotracker_scaled_online.pth", "config.json").
+    local_dir : str or Path
+        Local directory to download into.
+    overwrite : bool
+        If True, re-download even if the file already exists locally.
+
+    Returns
+    -------
+    local_path : Path
+        Path to the downloaded file.
+    """
+    local_dir = Path(local_dir)
+    local_path = local_dir / filename
+
+    if local_path.exists() and not overwrite:
+        print(f"File '{local_path}' exists. Skipping download.")
+        return local_path
+
+    print(f"Downloading {filename} from {COTRACKER_HF_REPO} ...")
+    cached_path = hf_hub_download(
+        repo_id=COTRACKER_HF_REPO,
+        filename=filename,
+        local_dir=local_dir,
+        local_dir_use_symlinks=False,
+    )
+    print(f"💾 Saved {filename} to {cached_path}")
+    return Path(cached_path)
+
+
+def check_cotracker_models(checkpoints_dir, force_download=False):
+    """
+    Ensure the Cotracker checkpoint and config are available locally.
+    Downloads them from HuggingFace if missing.
+
+    Returns a dictionary for the model-selection dropdown.
+
+    Parameters
+    ----------
+    checkpoints_dir : str or Path
+        Directory where cotracker.pt and config.json should reside
+        (typically ``<base_path>/cotracker_octron/checkpoints``).
+    force_download : bool
+        Re-download even if files exist.
+
+    Returns
+    -------
+    cotracker_models_dict : dict
+        Keys are model IDs, values contain 'name', 'checkpoint_path'.
+        Returns an empty dict if download fails.
+    """
+    checkpoints_dir = Path(checkpoints_dir)
+    if not checkpoints_dir.exists():
+        os.makedirs(checkpoints_dir, exist_ok=True)
+
+    try:
+        for fname in COTRACKER_FILES:
+            download_cotracker_file(
+                filename=fname,
+                local_dir=checkpoints_dir,
+                overwrite=force_download,
+            )
+    except Exception as e:
+        print(f"⚠️  Could not download Cotracker file: {e}")
+        return {}
+
+    # Verify the checkpoint actually landed
+    ckpt_path = checkpoints_dir / "scaled_online.pth"
+    if not ckpt_path.exists():
+        print("⚠️  cotracker checkpoint not found after download attempt.")
+        return {}
+
+    # Build the models dict (relative to cotracker_octron/)
+    cotracker_models_dict = {
+        "cotracker": {
+            "name": "Cotracker3",
+            "checkpoint_path": "checkpoints/scaled_online.pth",
+        }
+    }
+    return cotracker_models_dict

--- a/octron/gui_elements.py
+++ b/octron/gui_elements.py
@@ -316,13 +316,13 @@ class octron_gui_elements(QWidget):
 
         self.octron.model_select_grid_layout.addWidget(self.octron.sam3detect_thresh, 0, 2, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.octron.sam_model_list = QComboBox(self.octron.layoutWidget)
-        self.octron.sam_model_list.addItem("")
-        self.octron.sam_model_list.setObjectName(u"sam_model_list")
-        self.octron.sam_model_list.setMinimumSize(QSize(87, 25))
-        self.octron.sam_model_list.setMaximumSize(QSize(87, 25))
+        self.octron.prediction_model_list = QComboBox(self.octron.layoutWidget)
+        self.octron.prediction_model_list.addItem("")
+        self.octron.prediction_model_list.setObjectName(u"prediction_model_list")
+        self.octron.prediction_model_list.setMinimumSize(QSize(87, 25))
+        self.octron.prediction_model_list.setMaximumSize(QSize(87, 25))
 
-        self.octron.model_select_grid_layout.addWidget(self.octron.sam_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.octron.model_select_grid_layout.addWidget(self.octron.prediction_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
 
         self.octron.annotate_vertical_layout.addWidget(self.octron.model_select_groupbox, 0, Qt.AlignmentFlag.AlignTop)
@@ -1152,12 +1152,12 @@ class octron_gui_elements(QWidget):
         self.octron.sam3detect_thresh.setToolTip(QCoreApplication.translate("self", u"SAM3 multi only: Detection threshold for objects (0-1). Default is 0.5.", None))
 #endif // QT_CONFIG(tooltip)
         self.octron.sam3detect_thresh.setPlaceholderText(QCoreApplication.translate("self", u"0.5", None))
-        self.octron.sam_model_list.setItemText(0, QCoreApplication.translate("self", u"Model", None))
+        self.octron.prediction_model_list.setItemText(0, QCoreApplication.translate("self", u"Model", None))
 
 #if QT_CONFIG(tooltip)
-        self.octron.sam_model_list.setToolTip(QCoreApplication.translate("self", u"SAM models", None))
+        self.octron.prediction_model_list.setToolTip(QCoreApplication.translate("self", u"SAM models", None))
 #endif // QT_CONFIG(tooltip)
-        self.octron.sam_model_list.setCurrentText(QCoreApplication.translate("self", u"Model", None))
+        self.octron.prediction_model_list.setCurrentText(QCoreApplication.translate("self", u"Model", None))
         self.octron.annotate_layer_create_groupbox.setTitle(QCoreApplication.translate("self", u"Label manager", None))
         self.octron.layer_type_combobox.setItemText(0, QCoreApplication.translate("self", u"Type ... ", None))
         self.octron.layer_type_combobox.setItemText(1, QCoreApplication.translate("self", u"Shapes", None))

--- a/octron/main.py
+++ b/octron/main.py
@@ -179,7 +179,6 @@ class octron_widget(QWidget):
         # Populate Cotracker entries in the same dropdown
         for model_id, model in self.cotracker_models_dict.items():
             print(f"Adding model {model_id}")
-            # add it to sam model list for now?
             self.sam_model_list.addItem(model['name'])
             
         # Populate YOLO dropdown list with available models
@@ -575,8 +574,7 @@ class octron_widget(QWidget):
             print(f"Warning: reset_state during cleanup failed: {e}")
         
         # For SAM3_semantic_octron, also release the detector model
-        from octron.sam_octron.helpers.sam3_octron import (
-            SAM3_octron, SAM3_semantic_octron)
+        from octron.sam_octron.helpers.sam3_octron import SAM3_octron, SAM3_semantic_octron
         if isinstance(self.predictor, SAM3_semantic_octron):
             del self.predictor.detector
             del self.predictor.tracker.model
@@ -1587,6 +1585,8 @@ class octron_widget(QWidget):
         # Resize video frames if required
         predictor_image_size = self.predictor.image_size 
         if predictor_image_size is None:
+            # Cotracker does not require the input image to be a certain size,
+            # so we keep the original video dimensions.
             resized_height = video_height
             resized_width = video_width
         else:
@@ -1836,8 +1836,7 @@ class octron_widget(QWidget):
         if layer_type == 'Shapes':
             annotation_layer_name = f"{layer_name} shapes"
             # Create a shape layer
-            from octron.sam_octron.helpers.sam3_octron import \
-                SAM3_semantic_octron
+            from octron.sam_octron.helpers.sam3_octron import SAM3_semantic_octron
             if self.predictor is not None:
                 semantic_mode = isinstance(self.predictor, SAM3_semantic_octron)
             else:

--- a/octron/main.py
+++ b/octron/main.py
@@ -317,7 +317,7 @@ class octron_widget(QWidget):
 
     ###### SAM SPECIFIC CALLBACKS ####################################################################
     
-    def _check_model_data_compatibility(self, model_name):
+    def _check_sam_model_data_compatibility(self, model_name):
         """
         Check whether the model being loaded is compatible with existing
         annotation data.  SAM2 models operate at 1024×1024 while SAM3 models
@@ -383,8 +383,10 @@ class octron_widget(QWidget):
             model_name = self.sam_model_list.currentText()
 
         # Block loading if the model family is incompatible with existing data
-        # Only for SAM2 vs SAM3 since they have different expected image sizes. 
-        if not self._check_model_data_compatibility(model_name):
+        # Only for SAM2 vs SAM3 since they have different expected image sizes.
+        # CoTracker models bypass this check entirely.
+        is_cotracker = any(m['name'] == model_name for m in self.cotracker_models_dict.values())
+        if not is_cotracker and not self._check_sam_model_data_compatibility(model_name):
             return
 
         # Load SAM3 model if selected
@@ -489,7 +491,8 @@ class octron_widget(QWidget):
             self.sam3detect_thresh.setEnabled(True)
             self.threshold_label.setEnabled(True)
 
-    def load_cotrackermodel(self, model_name=''): 
+    def load_cotracker_model(self, model_name=''): 
+        """Load the selected CoTracker model and enable prediction controls."""
         # Get model_name from index
         if not model_name:
             index = self.sam_model_list.currentIndex()
@@ -505,7 +508,7 @@ class octron_widget(QWidget):
                 break
         assert model_found, f"Model '{model_name}' not found in Cotracker models dictionary."
         
-        # Download locally?
+        # Build model from local checkpoint
         model = self.cotracker_models_dict[model_id]
         checkpoint_path = self.base_path / Path(f"cotracker_octron/{model['checkpoint_path']}")
         self.predictor, self.device = build_cotracker(

--- a/octron/main.py
+++ b/octron/main.py
@@ -169,17 +169,17 @@ class octron_widget(QWidget):
         # Populate SAM2 dropdown list with available models
         for model_id, model in self.sam2models_dict.items():
             print(f"Adding SAM2 model {model_id}")
-            self.sam_model_list.addItem(model['name'])
+            self.prediction_model_list.addItem(model['name'])
         
         # Populate SAM3 entries in the same dropdown
         for model_id, model in self.sam3models_dict.items():
             print(f"Adding SAM3 model {model_id}")
-            self.sam_model_list.addItem(model['name'])
+            self.prediction_model_list.addItem(model['name'])
 
         # Populate Cotracker entries in the same dropdown
         for model_id, model in self.cotracker_models_dict.items():
             print(f"Adding model {model_id}")
-            self.sam_model_list.addItem(model['name'])
+            self.prediction_model_list.addItem(model['name'])
             
         # Populate YOLO dropdown list with available models
         for model_id, model in self.yolomodels_dict.items():
@@ -376,10 +376,10 @@ class octron_widget(QWidget):
         depending on whether the selected name is SAM2, SAM3 or cotracker
         """
         if not model_name:
-            index = self.sam_model_list.currentIndex()
+            index = self.prediction_model_list.currentIndex()
             if index == 0:
                 return
-            model_name = self.sam_model_list.currentText()
+            model_name = self.prediction_model_list.currentText()
 
         # Block loading if the model family is incompatible with existing data
         # Only for SAM2 vs SAM3 since they have different expected image sizes.
@@ -419,10 +419,10 @@ class octron_widget(QWidget):
         """
         if not model_name:
             # Assuming this is retrievable from current GUI ...             
-            index = self.sam_model_list.currentIndex()
+            index = self.prediction_model_list.currentIndex()
             if index == 0:
                 return
-            model_name = self.sam_model_list.currentText()
+            model_name = self.prediction_model_list.currentText()
         # Reverse lookup model_id
         model_found = False
         for model_id, model in self.sam2models_dict.items():
@@ -454,10 +454,10 @@ class octron_widget(QWidget):
             The name of the SAM3 model to load.
         """
         if not model_name:
-            index = self.sam_model_list.currentIndex()
+            index = self.prediction_model_list.currentIndex()
             if index == 0:
                 return
-            model_name = self.sam_model_list.currentText()
+            model_name = self.prediction_model_list.currentText()
         # Reverse lookup model_id
         model_found = False
         for model_id, model in self.sam3models_dict.items():
@@ -494,10 +494,10 @@ class octron_widget(QWidget):
         """Load the selected CoTracker model and enable prediction controls."""
         # Get model_name from index
         if not model_name:
-            index = self.sam_model_list.currentIndex()
+            index = self.prediction_model_list.currentIndex()
             if index == 0:
                 return
-            model_name = self.sam_model_list.currentText()
+            model_name = self.prediction_model_list.currentText()
 
         # Reverse lookup model_id
         model_found = False
@@ -533,8 +533,8 @@ class octron_widget(QWidget):
         """
         self.loaded_model_name = model_name
         # Deactivate the dropdown menu upon successful model loading
-        self.sam_model_list.setCurrentIndex(-1)
-        self.sam_model_list.setEnabled(False)
+        self.prediction_model_list.setCurrentIndex(-1)
+        self.prediction_model_list.setEnabled(False)
         self.load_sam_model_btn.setEnabled(False)
         self.load_sam_model_btn.setText(f'{model_name} ✓')
 
@@ -1048,8 +1048,8 @@ class octron_widget(QWidget):
         self.object_organizer = ObjectOrganizer()
         # SAM2 
         self.loaded_model_name = None
-        self.sam_model_list.setCurrentIndex(0)
-        self.sam_model_list.setEnabled(True)
+        self.prediction_model_list.setCurrentIndex(0)
+        self.prediction_model_list.setEnabled(True)
         self.load_sam_model_btn.setEnabled(True)
         self.load_sam_model_btn.setText(f'Load model')
         self.predict_next_batch_btn.setText('')
@@ -1093,9 +1093,9 @@ class octron_widget(QWidget):
             saved_model_name = saved_settings.get('model_name')
             if saved_model_name:
                 self.loaded_model_name = saved_model_name
-                idx = self.sam_model_list.findText(saved_model_name)
+                idx = self.prediction_model_list.findText(saved_model_name)
                 if idx >= 0:
-                    self.sam_model_list.setCurrentIndex(idx)
+                    self.prediction_model_list.setCurrentIndex(idx)
         
         # Clear the label list combobox and re-initialize it
         self.label_list_combobox.clear()
@@ -1311,8 +1311,8 @@ class octron_widget(QWidget):
                 # SAM2 
                 self._cleanup_predictor()
                 self.loaded_model_name = None
-                self.sam_model_list.setCurrentIndex(0)
-                self.sam_model_list.setEnabled(True)
+                self.prediction_model_list.setCurrentIndex(0)
+                self.prediction_model_list.setEnabled(True)
                 self.load_sam_model_btn.setEnabled(True)
                 self.load_sam_model_btn.setText(f'Load model')
                 self.predict_next_batch_btn.setText('')

--- a/octron/main.py
+++ b/octron/main.py
@@ -398,7 +398,7 @@ class octron_widget(QWidget):
         # Load cotracker model if selected
         for model_id, model in self.cotracker_models_dict.items():
             if model['name'] == model_name:
-                self.load_cotrackermodel(model_name=model_name)
+                self.load_cotracker_model(model_name=model_name)
                 return
             
         # Fall back to SAM2 otherwise

--- a/octron/main.py
+++ b/octron/main.py
@@ -528,7 +528,7 @@ class octron_widget(QWidget):
 
     def _on_model_loaded(self, model_name):
         """
-        Common post-load setup shared by SAM2 and SAM3.
+        Common post-load setup shared by SAM2, SAM3 and cotracker.
         Disables the dropdown, enables prediction controls, starts zarr prefetcher.
         """
         self.loaded_model_name = model_name

--- a/octron/main.py
+++ b/octron/main.py
@@ -1519,13 +1519,13 @@ class octron_widget(QWidget):
         
     def init_sam2_model(self):
         """
-        Initialize the SAM2 model for the current session.
-        This function requires a video to be loaded AND a model to be selected / loaded. 
+        Initialize the predictor for the current session.
+        This function requires a video to be loaded AND a model to be selected / loaded.
         It is called only once from within the prefetcher worker.
-        
+
         """
         if not self.predictor:
-            show_warning("Please select a SAM2 model first.")
+            show_warning("Please select a model first.")
             return
         if not self.video_layer:
             print("No video layer found.")
@@ -1533,18 +1533,25 @@ class octron_widget(QWidget):
         if not self.video_zarr:
             show_warning("No video zarr store found.")
             return
-        
-        # Prewarm SAM2 predictor (model)
-        # This needs the zarr store to be initialized first
-        # -> that happens when either the model is loaded or a video layer is found
-        # -> on_changed_layer() and load_sam2model() take care of this
+
         if not self.predictor.is_initialized:
-            self.predictor.init_state(video_data=self.video_layer.data, 
-                                      zarr_store=self.video_zarr,
-                                      )
+            from cotracker.predictor import CoTrackerOnlinePredictor
+            if isinstance(self.predictor, CoTrackerOnlinePredictor):
+                # CoTracker initialises on the first forward call
+                # (is_first_step=True), not via a separate init_state().
+                # TODO: PR3 will handle this.
+                pass
+            else:
+                # Initialise SAM2/SAM3 predictor
+                # This needs the zarr store to be initialized first
+                # -> that happens when either the model is loaded or a video layer is found
+                # -> on_changed_layer() and load_sam2model() take care of this
+                self.predictor.init_state(video_data=self.video_layer.data,
+                                          zarr_store=self.video_zarr,
+                                          )
             self.hard_reset_layer_btn.setEnabled(True)
             self.predictor.is_initialized = True
-            
+
         return
     
     def init_zarr_prefetcher_threaded(self):

--- a/octron/main.py
+++ b/octron/main.py
@@ -3,49 +3,40 @@ OCTRON
 Main GUI file
 
 """
-import os, sys
+import os
+import sys
 from typing import List, Optional
+
 # if using Apple MPS, fall back to CPU for unsupported ops
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 import shutil
-from datetime import datetime
 import warnings
+from datetime import datetime
+
 # Suppress specific warnings
 warnings.simplefilter("ignore")
 
 from pathlib import Path
+
 cur_path  = Path(os.path.abspath(__file__)).parent.parent
 base_path = Path(os.path.dirname(__file__)) # Important for example for .svg files
 sys.path.append(cur_path.as_posix()) 
 
 from importlib.metadata import version
+
 __version__ = version("octron")
 octron_version = __version__
 
-# Napari plugin QT components
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QWidget,
-    QDialog,
-    QApplication,
-    QStyleFactory,
-    QFileDialog,
-    QMessageBox,
-    QHeaderView,
-    QLabel,
-    QMenu,
-)
 import napari
-from napari.utils.notifications import (
-    show_info,
-    show_warning,
-    show_error,
-)
 from napari.qt import create_worker
 from napari.utils import DirectLabelColormap
-
+from napari.utils.notifications import show_error, show_info, show_warning
 # Napari PyAV reader 
 from napari_pyav._reader import FastVideoReader
+# Napari plugin QT components
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (QApplication, QDialog, QFileDialog, QHeaderView,
+                            QLabel, QMenu, QMessageBox, QStyleFactory, QWidget)
 
 # GUI 
 from octron.gui_elements import octron_gui_elements
@@ -54,47 +45,42 @@ from octron.gui_tables import ExistingDataTable
 # SAM2 specific 
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 import numpy as np
-from octron.sam_octron.helpers.video_loader import probe_video, get_vfile_hash
-from octron.sam_octron.helpers.build_sam2_octron import build_sam2_octron  
-from octron.sam_octron.helpers.sam2_checks import check_sam2_models
-from octron.sam_octron.helpers.build_sam3_octron import build_sam3_octron
-from octron.sam_octron.helpers.sam3_checks import check_sam3_models
 import zarr
-from octron.sam_octron.helpers.sam2_zarr import (
-    create_image_zarr,
-    load_image_zarr,
-    get_annotated_frames,
-    mark_frames_annotated,
-)
-# YOLO specific 
-from octron.yolo_octron.gui.yolo_handler import YoloHandler
-from octron.yolo_octron.helpers.training import collect_labels, load_object_organizer
-from octron.yolo_octron.yolo_octron import YOLO_octron
-from octron.yolo_octron.constants import TASK_COLORS
 
+# Cotracker
+from octron.cotracker_octron.helpers.build_cotracker import build_cotracker
+from octron.cotracker_octron.helpers.cotracker_checks import \
+    check_cotracker_models
+# Custom dialog boxes
+from octron.gui_dialog_elements import (add_new_label_dialog,
+                                        remove_label_dialog)
+from octron.sam_octron.helpers.build_sam2_octron import build_sam2_octron
+from octron.sam_octron.helpers.build_sam3_octron import build_sam3_octron
+from octron.sam_octron.helpers.sam2_checks import check_sam2_models
+# Annotation layer creation tools
+from octron.sam_octron.helpers.sam2_layer import (add_annotation_projection,
+                                                  add_sam2_mask_layer,
+                                                  add_sam2_points_layer,
+                                                  add_sam2_shapes_layer)
+# Layer callbacks classes
+from octron.sam_octron.helpers.sam2_layer_callback import sam2_octron_callbacks
+from octron.sam_octron.helpers.sam2_zarr import (create_image_zarr,
+                                                 get_annotated_frames,
+                                                 load_image_zarr,
+                                                 mark_frames_annotated)
+from octron.sam_octron.helpers.sam3_checks import check_sam3_models
+from octron.sam_octron.helpers.video_loader import get_vfile_hash, probe_video
+# OCTRON Object organizer
+from octron.sam_octron.object_organizer import Obj, ObjectOrganizer
 # Tracker specific 
 from octron.tracking.helpers.tracker_checks import load_boxmot_trackers
 from octron.tracking.helpers.tracker_vis import create_color_icon
-
-# Annotation layer creation tools
-from octron.sam_octron.helpers.sam2_layer import (
-    add_sam2_mask_layer,
-    add_sam2_shapes_layer,
-    add_sam2_points_layer,
-    add_annotation_projection,
-)                
-
-# Layer callbacks classes
-from octron.sam_octron.helpers.sam2_layer_callback import sam2_octron_callbacks
-
-# OCTRON Object organizer
-from octron.sam_octron.object_organizer import Obj, ObjectOrganizer
-  
-# Custom dialog boxes
-from octron.gui_dialog_elements import (
-    add_new_label_dialog,
-    remove_label_dialog,
-)
+from octron.yolo_octron.constants import TASK_COLORS
+# YOLO specific 
+from octron.yolo_octron.gui.yolo_handler import YoloHandler
+from octron.yolo_octron.helpers.training import (collect_labels,
+                                                 load_object_organizer)
+from octron.yolo_octron.yolo_octron import YOLO_octron
 
 # If there's already a QApplication instance (as may be the case when running as a napari plugin),
 # then set its style explicitly:
@@ -156,6 +142,9 @@ class octron_widget(QWidget):
         self.sam3models_dict = check_sam3_models(checkpoints_dir=sam3_checkpoints_dir,
                                                  force_download=False,
                                                  )
+        # cotracker3 checkpoint from HuggingFace
+        cotracker_checkpoints_dir = self.base_path / 'cotracker_octron'/'checkpoints'
+        self.cotracker_models_dict = check_cotracker_models(checkpoints_dir=cotracker_checkpoints_dir, force_download=False)
         
         # Model yaml for YOLO
         yolo_models_yaml_path = self.base_path / 'yolo_octron/yolo_models.yaml'
@@ -185,6 +174,12 @@ class octron_widget(QWidget):
         # Populate SAM3 entries in the same dropdown
         for model_id, model in self.sam3models_dict.items():
             print(f"Adding SAM3 model {model_id}")
+            self.sam_model_list.addItem(model['name'])
+
+        # Populate Cotracker entries in the same dropdown
+        for model_id, model in self.cotracker_models_dict.items():
+            print(f"Adding model {model_id}")
+            # add it to sam model list for now?
             self.sam_model_list.addItem(model['name'])
             
         # Populate YOLO dropdown list with available models
@@ -378,8 +373,8 @@ class octron_widget(QWidget):
     def load_model(self, model_name=''):
         """
         Dispatcher: load the selected model from the dropdown.
-        Delegates to load_sam2model or load_sam3model depending on
-        whether the selected name belongs to SAM2 or SAM3.
+        Delegates to load_sam2model, load_sam3model or load_cotracker_model 
+        depending on whether the selected name is SAM2, SAM3 or cotracker
         """
         if not model_name:
             index = self.sam_model_list.currentIndex()
@@ -388,17 +383,25 @@ class octron_widget(QWidget):
             model_name = self.sam_model_list.currentText()
 
         # Block loading if the model family is incompatible with existing data
+        # Only for SAM2 vs SAM3 since they have different expected image sizes. 
         if not self._check_model_data_compatibility(model_name):
             return
 
-        # Check SAM3 first
+        # Load SAM3 model if selected
         for model_id, model in self.sam3models_dict.items():
             if model['name'] == model_name:
                 self.load_sam3model(model_name=model_name)
                 return
-        # Fall back to SAM2
+        
+        # Load cotracker model if selected
+        for model_id, model in self.cotracker_models_dict.items():
+            if model['name'] == model_name:
+                self.load_cotrackermodel(model_name=model_name)
+                return
+            
+        # Fall back to SAM2 otherwise
         self.load_sam2model(model_name=model_name)
-    
+
     def load_sam2model(self, 
                        model_name='',
                        ):
@@ -486,6 +489,41 @@ class octron_widget(QWidget):
             self.sam3detect_thresh.setEnabled(True)
             self.threshold_label.setEnabled(True)
 
+    def load_cotrackermodel(self, model_name=''): 
+        # Get model_name from index
+        if not model_name:
+            index = self.sam_model_list.currentIndex()
+            if index == 0:
+                return
+            model_name = self.sam_model_list.currentText()
+
+        # Reverse lookup model_id
+        model_found = False
+        for model_id, model in self.cotracker_models_dict.items():
+            if model['name'] == model_name:
+                model_found = True
+                break
+        assert model_found, f"Model '{model_name}' not found in Cotracker models dictionary."
+        
+        # Download locally?
+        model = self.cotracker_models_dict[model_id]
+        checkpoint_path = self.base_path / Path(f"cotracker_octron/{model['checkpoint_path']}")
+        self.predictor, self.device = build_cotracker(
+            ckpt_path=checkpoint_path.as_posix(),
+        )
+        self.predictor.is_initialized = False
+        show_info(f"Model {model_name} loaded on {self.device}")
+
+        # Set cache size
+        self.chunk_size = 15
+        self._on_model_loaded(model_name)
+
+        # Disable shapes and bboxes options for cotracker
+        index_to_disable = [1, 3] # shapes, anchors (bboxes)
+        for ind in index_to_disable:  
+            self.layer_type_combobox.model().item(ind).setEnabled(False)
+
+
     def _on_model_loaded(self, model_name):
         """
         Common post-load setup shared by SAM2 and SAM3.
@@ -515,7 +553,6 @@ class octron_widget(QWidget):
         # Enable the annotation layer creation tab
         self.annotate_layer_create_groupbox.setEnabled(True)
         
-        
     def _cleanup_predictor(self):
         """
         Fully release the current predictor and free GPU memory.
@@ -535,7 +572,8 @@ class octron_widget(QWidget):
             print(f"Warning: reset_state during cleanup failed: {e}")
         
         # For SAM3_semantic_octron, also release the detector model
-        from octron.sam_octron.helpers.sam3_octron import SAM3_semantic_octron, SAM3_octron
+        from octron.sam_octron.helpers.sam3_octron import (
+            SAM3_octron, SAM3_semantic_octron)
         if isinstance(self.predictor, SAM3_semantic_octron):
             del self.predictor.detector
             del self.predictor.tracker.model
@@ -1506,7 +1544,6 @@ class octron_widget(QWidget):
             
         return
     
-        
     def init_zarr_prefetcher_threaded(self):
         """
         This function deals with storage (temporary and long term).
@@ -1530,24 +1567,28 @@ class octron_widget(QWidget):
         if not self.predictor:
             # only when a model is loaded
             return
-        
+
         # Collect some info about video layer before loading or creating zarr archive
-        metadata =  self.video_layer.metadata
+        metadata = self.video_layer.metadata
         num_frames = metadata['num_frames']
         video_height = metadata['height']
         video_width = metadata['width']    
-        predictor_image_size = self.predictor.image_size # SAM2 model image size
-        largest_edge = max(video_height, video_width) 
 
-        # Resize both (!) edges to the same square size matching the model's expected input.
-        # Use predictor_image_size directly to avoid floating-point rounding errors
-        # (e.g. int(floor(1008/1337*1337)) can yield 1007 instead of 1008).
-        resized_height = predictor_image_size
-        resized_width = predictor_image_size
+        # Resize video frames if required
+        predictor_image_size = self.predictor.image_size 
+        if predictor_image_size is None:
+            resized_height = video_height
+            resized_width = video_width
+        else:
+            # For SAM2 and SAM3 models:
+            # Resize both (!) edges to the same square size matching the model's expected input.
+            # Use predictor_image_size directly to avoid floating-point rounding errors
+            # (e.g. int(floor(1008/1337*1337)) can yield 1007 instead of 1008).
+            resized_height = predictor_image_size
+            resized_width = predictor_image_size
         print(f'📐 Resized video dimensions: {resized_height}x{resized_width}')
         
         # Create zarr store for video layer
-        
         video_zarr_path = self.project_path_video / 'video data.zarr'
         status = False
         
@@ -1600,7 +1641,6 @@ class octron_widget(QWidget):
         self.prefetcher_worker.setAutoDelete(False)
         self.prefetcher_worker.start()
         
-    
     def on_label_change(self):
         """
         Callback function for the label list combobox.
@@ -1786,7 +1826,8 @@ class octron_widget(QWidget):
         if layer_type == 'Shapes':
             annotation_layer_name = f"{layer_name} shapes"
             # Create a shape layer
-            from octron.sam_octron.helpers.sam3_octron import SAM3_semantic_octron
+            from octron.sam_octron.helpers.sam3_octron import \
+                SAM3_semantic_octron
             if self.predictor is not None:
                 semantic_mode = isinstance(self.predictor, SAM3_semantic_octron)
             else:

--- a/octron/qt_gui/octron.py
+++ b/octron/qt_gui/octron.py
@@ -222,13 +222,13 @@ class Ui_octron_widgetui(object):
 
         self.model_select_grid_layout.addWidget(self.sam3detect_thresh, 0, 2, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.sam_model_list = QComboBox(self.layoutWidget)
-        self.sam_model_list.addItem("")
-        self.sam_model_list.setObjectName(u"sam_model_list")
-        self.sam_model_list.setMinimumSize(QSize(87, 25))
-        self.sam_model_list.setMaximumSize(QSize(87, 25))
+        self.prediction_model_list = QComboBox(self.layoutWidget)
+        self.prediction_model_list.addItem("")
+        self.prediction_model_list.setObjectName(u"prediction_model_list")
+        self.prediction_model_list.setMinimumSize(QSize(87, 25))
+        self.prediction_model_list.setMaximumSize(QSize(87, 25))
 
-        self.model_select_grid_layout.addWidget(self.sam_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.model_select_grid_layout.addWidget(self.prediction_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
 
         self.annotate_vertical_layout.addWidget(self.model_select_groupbox, 0, Qt.AlignmentFlag.AlignTop)
@@ -1063,12 +1063,12 @@ class Ui_octron_widgetui(object):
         self.sam3detect_thresh.setToolTip(QCoreApplication.translate("octron_widgetui", u"SAM3 multi only: Detection threshold for objects (0-1). Default is 0.5.", None))
 #endif // QT_CONFIG(tooltip)
         self.sam3detect_thresh.setPlaceholderText(QCoreApplication.translate("octron_widgetui", u"0.5", None))
-        self.sam_model_list.setItemText(0, QCoreApplication.translate("octron_widgetui", u"Model", None))
+        self.prediction_model_list.setItemText(0, QCoreApplication.translate("octron_widgetui", u"Model", None))
 
 #if QT_CONFIG(tooltip)
-        self.sam_model_list.setToolTip(QCoreApplication.translate("octron_widgetui", u"SAM models", None))
+        self.prediction_model_list.setToolTip(QCoreApplication.translate("octron_widgetui", u"SAM models", None))
 #endif // QT_CONFIG(tooltip)
-        self.sam_model_list.setCurrentText(QCoreApplication.translate("octron_widgetui", u"Model", None))
+        self.prediction_model_list.setCurrentText(QCoreApplication.translate("octron_widgetui", u"Model", None))
         self.annotate_layer_create_groupbox.setTitle(QCoreApplication.translate("octron_widgetui", u"Label manager", None))
         self.layer_type_combobox.setItemText(0, QCoreApplication.translate("octron_widgetui", u"Type ... ", None))
         self.layer_type_combobox.setItemText(1, QCoreApplication.translate("octron_widgetui", u"Shapes", None))

--- a/octron/qt_gui/octron.ui
+++ b/octron/qt_gui/octron.ui
@@ -596,7 +596,7 @@
               </widget>
              </item>
              <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter">
-              <widget class="QComboBox" name="sam_model_list">
+              <widget class="QComboBox" name="prediction_model_list">
                <property name="minimumSize">
                 <size>
                  <width>87</width>

--- a/octron/qt_gui/octron_corrected.py
+++ b/octron/qt_gui/octron_corrected.py
@@ -222,13 +222,13 @@ class Ui_octron_widgetui(object):
 
         self.octron.model_select_grid_layout.addWidget(self.octron.sam3detect_thresh, 0, 2, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
-        self.octron.sam_model_list = QComboBox(self.octron.layoutWidget)
-        self.octron.sam_model_list.addItem("")
-        self.octron.sam_model_list.setObjectName(u"sam_model_list")
-        self.octron.sam_model_list.setMinimumSize(QSize(87, 25))
-        self.octron.sam_model_list.setMaximumSize(QSize(87, 25))
+        self.octron.prediction_model_list = QComboBox(self.octron.layoutWidget)
+        self.octron.prediction_model_list.addItem("")
+        self.octron.prediction_model_list.setObjectName(u"prediction_model_list")
+        self.octron.prediction_model_list.setMinimumSize(QSize(87, 25))
+        self.octron.prediction_model_list.setMaximumSize(QSize(87, 25))
 
-        self.octron.model_select_grid_layout.addWidget(self.octron.sam_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.octron.model_select_grid_layout.addWidget(self.octron.prediction_model_list, 0, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
 
 
         self.octron.annotate_vertical_layout.addWidget(self.octron.model_select_groupbox, 0, Qt.AlignmentFlag.AlignTop)
@@ -1058,12 +1058,12 @@ class Ui_octron_widgetui(object):
         self.octron.sam3detect_thresh.setToolTip(QCoreApplication.translate("self", u"SAM3 multi only: Detection threshold for objects (0-1). Default is 0.5.", None))
 #endif // QT_CONFIG(tooltip)
         self.octron.sam3detect_thresh.setPlaceholderText(QCoreApplication.translate("self", u"0.5", None))
-        self.octron.sam_model_list.setItemText(0, QCoreApplication.translate("self", u"Model", None))
+        self.octron.prediction_model_list.setItemText(0, QCoreApplication.translate("self", u"Model", None))
 
 #if QT_CONFIG(tooltip)
-        self.octron.sam_model_list.setToolTip(QCoreApplication.translate("self", u"SAM models", None))
+        self.octron.prediction_model_list.setToolTip(QCoreApplication.translate("self", u"SAM models", None))
 #endif // QT_CONFIG(tooltip)
-        self.octron.sam_model_list.setCurrentText(QCoreApplication.translate("self", u"Model", None))
+        self.octron.prediction_model_list.setCurrentText(QCoreApplication.translate("self", u"Model", None))
         self.octron.annotate_layer_create_groupbox.setTitle(QCoreApplication.translate("self", u"Label manager", None))
         self.octron.layer_type_combobox.setItemText(0, QCoreApplication.translate("self", u"Type ... ", None))
         self.octron.layer_type_combobox.setItemText(1, QCoreApplication.translate("self", u"Shapes", None))

--- a/octron/sam_octron/helpers/sam2_layer_callback.py
+++ b/octron/sam_octron/helpers/sam2_layer_callback.py
@@ -464,6 +464,12 @@ class sam2_octron_callbacks():
         """
         predictor = self.octron.predictor
         assert predictor, "No model loaded."
+
+        # CoTracker does not use the SAM2/SAM3 OctoZarr image cache yet.
+        # TODO (PR 3): wire CoTrackerOnlinePredictor with init_state() and OctoZarr.
+        if not hasattr(predictor, 'images'):
+            return
+
         self.octron.init_sam2_model() # This initializes the model if it is not yet initialized
         
         viewer = self.octron._viewer    

--- a/octron/sam_octron/helpers/sam2_layer_callback.py
+++ b/octron/sam_octron/helpers/sam2_layer_callback.py
@@ -1,22 +1,24 @@
 # OCTRON SAM2 related callbacks
 import time
+import warnings
+
 import numpy as np
-import cmasher as cmr
-from napari.utils import DirectLabelColormap
-from octron.sam_octron.helpers.sam2_octron import (
-    SAM2_octron,
-    run_new_pred,
-)
-from octron.sam_octron.helpers.sam2_colors import sample_maximally_different, create_semantic_colormap
-from octron.sam_octron.helpers.sam2_zarr import mark_frames_annotated
+from cotracker.predictor import CoTrackerOnlinePredictor
 from napari.utils.notifications import (
-    show_warning,
-    show_info,
     show_error,
+    show_warning,
 )
 
-import warnings 
+from octron.sam_octron.helpers.sam2_colors import (
+    create_semantic_colormap,
+)
+from octron.sam_octron.helpers.sam2_octron import (
+    run_new_pred,
+)
+from octron.sam_octron.helpers.sam2_zarr import mark_frames_annotated
+
 warnings.simplefilter("ignore")
+
 
 class sam2_octron_callbacks():
     """
@@ -164,7 +166,6 @@ class sam2_octron_callbacks():
             # Catching all above with ['added','removed','changed']
             pass
         return
-    
     
     def _handle_semantic_box_detection(
         self,
@@ -356,7 +357,6 @@ class sam2_octron_callbacks():
         
         return id_mask
     
-    
     def on_points_changed(self, event):
         """
         Callback function for napari annotation "Points" layer.
@@ -454,7 +454,6 @@ class sam2_octron_callbacks():
             pass
         return    
     
-    
     def prefetch_images(self):
         """
         Thread worker for prefetching images for fast processing in the viewer
@@ -467,7 +466,7 @@ class sam2_octron_callbacks():
 
         # CoTracker does not use the SAM2/SAM3 OctoZarr image cache yet.
         # TODO (PR 3): wire CoTrackerOnlinePredictor with init_state() and OctoZarr.
-        if not hasattr(predictor, 'images'):
+        if isinstance(predictor, CoTrackerOnlinePredictor):
             return
 
         self.octron.init_sam2_model() # This initializes the model if it is not yet initialized
@@ -512,7 +511,6 @@ class sam2_octron_callbacks():
             t1 = time.perf_counter()
             print(f'⚡️ Pre-computed backbone features for {len(prefetch_indices)} frames in {t1-t0:.2f}s')
 
-    
     def next_predict(self):
         """
         Threaded function to run the predictor forward on exactly one frame.
@@ -562,7 +560,6 @@ class sam2_octron_callbacks():
         self.octron.chunk_size = chunk_size_real
         return
 
-    
     def batch_predict(self):
         """
         Threaded function to run the predictor forward on a batch of frames.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "sam-2 @ https://github.com/horsto/sam2/releases/download/v0.0.2/sam_2-1.0-py3-none-any.whl",
     "boxmot @ https://github.com/horsto/boxmot/releases/download/v.15.0.5.2/boxmot-15.0.5-py3-none-any.whl",
     "timm>=1.0.25",
-    "clip @ git+https://github.com/ultralytics/CLIP.git"
+    "clip @ git+https://github.com/ultralytics/CLIP.git",
+    "cotracker @ git+https://github.com/facebookresearch/co-tracker.git"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds initial support for loading the CoTracker3 point-tracking model alongside the existing SAM2/SAM3 models. It is the first part of a series towards support Cotracker in OCTRON.

## Context
CoTracker3 is a point-tracking model that takes a set of query points on a frame and tracks their (x, y) positions across subsequent frames. This fits well into OCTRON's existing distillation paradigm, which uses foundation models to generate annotations, which are then use to train smaller models with a narrower focus (e.g. YOLO pose estimation models with a custom skeleton).

The rough PR plan (concocted with Claude) is included in the collapsible panel below. The work in this PR would correspond to PR2 of the plan below.

<details>

### PR 1: Skeleton definition + keypoint combobox UI

- `SkeletonDefinition` pydantic model (keypoint names, optional connectivity)
- Skeleton setup dialog (type names line-by-line or load from YAML)
- `keypoint_combobox` in GUI panel, auto-advances on click
- Keypoint index stored in napari Points layer `features`
- Text labels + per-keypoint colors on the Points layer
- Skeleton definition serialized in project JSON

### PR 2: CoTracker3 model loading

- `build_cotracker.py` — load from torch hub or local checkpoint
- CoTracker option in model loading dialog
- `self.model_type` field to branch downstream logic

### PR 3: CoTracker3 predictor wrapper + OctoZarr integration

- `cotracker_octron.py`:
    - `init_state()` — OctoZarr with CoTracker normalization/input size
    - `add_query_points(frame_idx, obj_id, points, keypoint_indices)`
    - `propagate_in_video(start_frame, end_frame)` — yield per-frame results
- Per-object trajectory zarr `(T, N_keypoints, 3)` — allocated to full skeleton size
- Undefined keypoints stored as `(0, 0, 0)` (visibility=0)
- Zarr creation/loading utilities

### PR 4: UI callbacks + napari visualization (includes multi-animal)

- CoTracker `on_points_changed` callback — reads keypoint combobox, collects per object
- Wire predict/propagate buttons for cotracker mode
- Results displayed as napari Tracks layer with per-object colors
- Skeleton line overlay (Shapes layer) if connectivity defined
- Multi-animal works via existing `ObjectOrganizer` — each animal is an `obj_id`, missing keypoints get visibility=0

### PR 5: YOLO pose export

- `trajectory_zarr_to_yolo_pose()`:
    - Bounding box from keypoint min/max + padding
    - YOLO pose `.txt` labels per frame
    - Dataset YAML with skeleton definition + connectivity
    - Visibility mapping (0 = not defined or CoTracker lost track, 2 = visible)
- "Export to YOLO Pose" button in UI
- Optional quality filter (e.g. only frames with ≥ N visible keypoints)
</details>

### This PR
#### New files
* `octron/cotracker_octron/helpers/build_cotracker.py`: builds a CoTrackerOnlinePredictor from a local checkpoint, selects device (CUDA/MPS/CPU), and sets image_size = None (native video resolution).
* `octron/cotracker_octron/helpers/cotracker_checks.py`: downloads the scaled_online.pth checkpoint from HuggingFace (facebook/cotracker3) if missing, and returns a model-dict for the dropdown.

#### Key changes in `main.py`
* On startup, checks for/downloads the CoTracker checkpoint and populates it into the model dropdown alongside SAM2/SAM3.
* New `load_cotracker_model()` method loads the model, sets `chunk_size = 15`, disables the Shapes and Bounding Box layer type options (not applicable to CoTracker), and calls the shared `_on_model_loaded()` post-load setup.
* `load_model()` dispatcher updated to route to `load_cotracker_model()` for CoTracker names, and to skip the SAM2/SAM3 image-size compatibility check for CoTracker.
* `init_sam2_model()` updated to skip SAM-style `init_state()` for `CoTrackerOnlinePredictor` (CoTracker initialises on first forward call instead) — marked as TODO for next PR.
* `init_zarr_prefetcher_threaded()` updated: when `predictor.image_size` is None (CoTracker), the zarr store uses the original video dimensions rather than resizing to a square.
* Rename: `sam_model_list` → `prediction_model_list`: the model-selection dropdown widget was renamed across all GUI files to reflect that it now holds SAM and CoTracker models.

#### Other changes
* cotracker added as a dependency in `pyproject.toml`
* `.gitignore` updated to exclude *.pth files (CoTracker checkpoint format).
* `_check_model_data_compatibility` renamed to `_check_sam_model_data_compatibility` for clarity.
* Import ordering cleaned up throughout `main.py`.

It also adds two guards (marked with a commented `TODO`s) to allow the model to correctly load. These will be properly dealt with in subsequent PRs. These guards are:
* one in `octron/sam_octron/helpers/sam2_layer_callback.py`, to skip SAM2-specific image-cache logic when CoTracker is loaded (it lacks a .images attribute).
* one in `octron/main.py`, when setting the initial state of the predictor model


#### Testing
The PR has been tested locally on my Mac with mps and in an ubuntu machine with an NVIDIA GPU.

I also added some basic tests for the functionality added here as part of a separate PR.


I am not super familiar with the codebase yet (tho it was fun to explore it with Claude) - feel free to make suggestions or changes directly in this PR. 

