### PR TITLE
feat: add output_dir parameter to predict_batch()

### DIFF
--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1788,6 +1788,7 @@ class YOLO_octron:
                   opening_radius=0,
                   overwrite=True,
                   buffer_size=500,
+                  output_dir=None,
                   ):
         """
         Predict and track objects in multiple videos.
@@ -1854,6 +1855,9 @@ class YOLO_octron:
             Whether to overwrite existing prediction results
         buffer_size : int, default=500
             Number of frames to buffer before writing masks to zarr arrays
+        output_dir : str or Path, optional
+            Root directory under which octron_predictions/ folders are written.
+            Defaults to alongside each video file when None.
             
         Yields
         ------
@@ -1989,7 +1993,8 @@ class YOLO_octron:
             video_path = Path(video_dict['video_file_path'])
             
             # Check overwrite BEFORE loading the model to avoid unnecessary work
-            save_dir = video_path.parent / 'octron_predictions' / f"{video_path.stem}_{tracker_name}"
+            _pred_root = Path(output_dir) if output_dir else video_path.parent
+            save_dir = _pred_root / 'octron_predictions' / f"{video_path.stem}_{tracker_name}"
             if save_dir.exists() and overwrite:
                 shutil.rmtree(save_dir)
             elif save_dir.exists() and not overwrite:


### PR DESCRIPTION
## Summary

- Adds `output_dir=None` parameter to `predict_batch()` in `yolo_octron.py`
- When provided, `octron_predictions/` folders are written under `output_dir` instead of alongside each video file
- Default is `None`, preserving existing behaviour exactly
- No other logic changed

This PR is just laying down a bit of foundation for the CLI, allowing users to choose where they want their predictions to end up.

## Test plan

- [ ] Try running `octron-gui` and see that the path is like before - ensuring that the GUI behaviour hasn't changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code), @roaldarbol edited tests afterwards.