### PR TITLE
fix: YOLO26 mask metrics=0 during training

### DIFF
--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1355,20 +1355,11 @@ class YOLO_octron:
                     # validation — resulting in mask metrics = 0 for all epochs.
                     train_kwargs['mask_ratio'] = 1
                     train_kwargs['overlap_mask'] = True
-                    # YOLO26 has a semantic-segmentation head (sem_loss) that
-                    # requires per-pixel class-label targets.  OCTRON provides
-                    # instance-level polygon labels only.  Disabling the semantic
-                    # loss prevents sem_loss from diverging to NaN when it cannot
-                    # find valid semantic targets.
-                    # Only set this for YOLO26 models (identified by the Segment26
-                    # head) — YOLO11 does not have this parameter and passing it
-                    # would cause an unrecognised-argument error.
-                    try:
-                        head_type = type(list(self.model.model.model.children())[-1]).__name__
-                    except Exception:
-                        head_type = ''
-                    if 'Segment26' in head_type:
-                        train_kwargs['semseg_loss'] = False
+                    # Note: YOLO26 was trained with semseg_loss=True in its
+                    # custom ultralytics fork, but the standard ultralytics
+                    # rejects it as an unrecognised argument. Since the standard
+                    # trainer has no semantic-loss code, sem_loss is not computed
+                    # at all — no action needed here.
 
                 self.model.train(**train_kwargs)
             except Exception as e:

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1260,20 +1260,17 @@ class YOLO_octron:
             return avg_h, avg_w, rect
 
         # Remove any stale ultralytics disk-cache .npy files from the training
-        # data directory before starting.  ultralytics cache='disk' (older
-        # versions) writes <stem>.npy alongside each source image.  YOLO26's
-        # semantic-segmentation head also scans for <stem>.npy files and
-        # interprets them as per-pixel class-label maps.  Stale cache files
-        # therefore contain raw RGB frames instead of label maps, which poisons
-        # sem_loss and eventually causes a NaN crash (observed at epoch ~76 on
-        # RTX 5090 with yolo26l-seg).  Removing them forces a clean rebuild and
-        # prevents the semantic head from receiving corrupted targets.
+        # data directory before starting.  ultralytics cache='disk' writes
+        # <stem>.npy files alongside source images, and BaseDataset.load_image
+        # will silently load any matching .npy it finds — even when cache='disk'
+        # is not set — instead of reading the actual image file.  Purging them
+        # here ensures a clean cache rebuild each training run.
         if self.data_path and self.data_path.exists():
             stale_npy = list(self.data_path.glob('**/*.npy'))
             if stale_npy:
                 logger.warning(
-                    f"Found {len(stale_npy)} stale .npy file(s) in training data "
-                    "directory — removing to prevent corrupted semantic-mask targets."
+                    f"Found {len(stale_npy)} stale .npy cache file(s) in training data "
+                    "directory — removing before training starts."
                 )
                 for f in stale_npy:
                     f.unlink()
@@ -1323,7 +1320,7 @@ class YOLO_octron:
                     patience=100,
                     plots=True,
                     batch=-1, # auto
-                    cache=False,
+                    cache='disk', # for fast access
                     save=True,
                     save_period=save_period, 
                     exist_ok=True,

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1259,6 +1259,25 @@ class YOLO_octron:
             
             return avg_h, avg_w, rect
 
+        # Remove any stale ultralytics disk-cache .npy files from the training
+        # data directory before starting.  ultralytics cache='disk' (older
+        # versions) writes <stem>.npy alongside each source image.  YOLO26's
+        # semantic-segmentation head also scans for <stem>.npy files and
+        # interprets them as per-pixel class-label maps.  Stale cache files
+        # therefore contain raw RGB frames instead of label maps, which poisons
+        # sem_loss and eventually causes a NaN crash (observed at epoch ~76 on
+        # RTX 5090 with yolo26l-seg).  Removing them forces a clean rebuild and
+        # prevents the semantic head from receiving corrupted targets.
+        if self.data_path and self.data_path.exists():
+            stale_npy = list(self.data_path.glob('**/*.npy'))
+            if stale_npy:
+                logger.warning(
+                    f"Found {len(stale_npy)} stale .npy file(s) in training data "
+                    "directory — removing to prevent corrupted semantic-mask targets."
+                )
+                for f in stale_npy:
+                    f.unlink()
+
         self.model.add_callback("on_fit_epoch_end", _on_fit_epoch_end)
         self.model.add_callback("on_train_end", _on_train_end)
         
@@ -1304,7 +1323,7 @@ class YOLO_octron:
                     patience=100,
                     plots=True,
                     batch=-1, # auto
-                    cache='disk', # for fast access
+                    cache=False,
                     save=True,
                     save_period=save_period, 
                     exist_ok=True,
@@ -1329,8 +1348,27 @@ class YOLO_octron:
                 )
                 # Segmentation-specific parameters
                 if train_mode == 'segment':
-                    train_kwargs['mask_ratio'] = 2
+                    # mask_ratio=1 matches the YOLO26 prototype head's design
+                    # resolution. Using mask_ratio=2 causes YOLO26's mask
+                    # predictions to be at half the expected resolution, which
+                    # prevents any mask IoU threshold from being met during
+                    # validation — resulting in mask metrics = 0 for all epochs.
+                    train_kwargs['mask_ratio'] = 1
                     train_kwargs['overlap_mask'] = True
+                    # YOLO26 has a semantic-segmentation head (sem_loss) that
+                    # requires per-pixel class-label targets.  OCTRON provides
+                    # instance-level polygon labels only.  Disabling the semantic
+                    # loss prevents sem_loss from diverging to NaN when it cannot
+                    # find valid semantic targets.
+                    # Only set this for YOLO26 models (identified by the Segment26
+                    # head) — YOLO11 does not have this parameter and passing it
+                    # would cause an unrecognised-argument error.
+                    try:
+                        head_type = type(list(self.model.model.model.children())[-1]).__name__
+                    except Exception:
+                        head_type = ''
+                    if 'Segment26' in head_type:
+                        train_kwargs['semseg_loss'] = False
 
                 self.model.train(**train_kwargs)
             except Exception as e:


### PR DESCRIPTION
## Summary

- **`mask metrics = 0` throughout all training epochs** — `mask_ratio=2` causes a resolution mismatch with YOLO26's `Proto26` head. Unlike YOLO11's standard `Proto`, `Proto26` contains its own internal upsampler and was designed to output full-resolution prototype masks. Setting `mask_ratio=2` makes ultralytics compare predictions at half resolution against full-resolution targets during validation, so no mask ever meets the IoU threshold. Fixed: `mask_ratio=1`, matching the value recorded in the model's own stored `train_args`. Safe for YOLO11 — higher resolution masks use more memory but are not incorrect.

- **Stale `.npy` cache files purged before training** — `cache='disk'` writes `<stem>.npy` files alongside images, and ultralytics will silently load any matching `.npy` it finds on subsequent runs even without `cache='disk'` set. Any stale files from a previous training run are now deleted before training starts to ensure a clean cache rebuild.

**Note on `semseg_loss`:** YOLO26 was originally trained with `semseg_loss=True` in a custom ultralytics fork. Standard ultralytics does not implement semantic loss — no action is needed.

## Test plan

- [ ] Train with `yolo26l-seg` on a single-class dataset and verify `mask metrics > 0` from the first evaluation epoch
- [ ] Confirm no `.npy` files remain in the training data directory after training starts
- [ ] Train with `yolo11m-seg` and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)