### PR TITLE
Update ultralytics resume logic

### DIFF
--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -659,6 +659,17 @@ class YoloHandler(QObject):
                     show_warning("Checkpoint does not contain image size info. Cannot continue from checkpoint.")
                     return
                 self.image_size_yolo = int(train_args['imgsz'])
+                if self.image_size_yolo <= 0:
+                    # imgsz was corrupted (e.g. by a previous bad resume) —
+                    # recompute it from the actual training images so the scale
+                    # the model was originally trained on is exactly preserved.
+                    _avg_h, _avg_w, _ = self.yolo._find_train_image_size(self.yolo.data_path)
+                    _largest = max(_avg_h, _avg_w)
+                    self.image_size_yolo = int(((_largest + 31) // 32) * 32)
+                    logger.warning(
+                        f"Checkpoint imgsz was 0 (corrupted). "
+                        f"Recomputed from training data: imgsz={self.image_size_yolo}"
+                    )
 
                 if ckpt_epoch == -1:
                     # Completed run: strict resume is not possible, but we can continue

--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -647,30 +647,45 @@ class YoloHandler(QObject):
         
         # Check for resume first: model/image-size selections are irrelevant when resuming
         self.resume_training = False
+        self.init_from_checkpoint = False
         if self.w.train_resume_checkBox.isChecked():
             checkpoint_path = self.yolo.training_path / 'training' / 'weights' / 'last.pt'
             if checkpoint_path.exists():
                 # Check whether the previous training run already completed
                 ckpt = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
                 ckpt_epoch = ckpt.get('epoch', -1)
-                if ckpt_epoch == -1:
-                    show_warning(
-                        "The previous training run already completed all epochs. "
-                        "Nothing to resume. Uncheck 'Resume' to start a new training run."
-                    )
+                train_args = ckpt.get('train_args', {})
+                if 'imgsz' not in train_args:
+                    show_warning("Checkpoint does not contain image size info. Cannot continue from checkpoint.")
                     return
-                logger.info(f"Resuming training from checkpoint: {checkpoint_path} (epoch {ckpt_epoch})")
+                self.image_size_yolo = int(train_args['imgsz'])
+
+                if ckpt_epoch == -1:
+                    # Completed run: strict resume is not possible, but we can continue
+                    # training by initializing a new run from last.pt.
+                    logger.info(
+                        "Resume requested, but checkpoint indicates a completed run "
+                        f"(epoch={ckpt_epoch}). Initializing new training from {checkpoint_path}."
+                    )
+                    show_info(
+                        "Checkpoint is from a completed run. Continuing training from last.pt "
+                        "as initialization (new run), not strict resume."
+                    )
+                    self.init_from_checkpoint = True
+                else:
+                    logger.info(f"Resuming training from checkpoint: {checkpoint_path} (epoch {ckpt_epoch})")
+                    self.resume_training = True
+
                 yolo_model = self.yolo.load_model(checkpoint_path, train_mode=self.w.train_mode)
                 if not yolo_model:
                     show_warning("Could not load checkpoint model.")
                     return
-                self.resume_training = True
-                self.image_size_yolo = 0  # Ignored by YOLO when resume=True
+                logger.info(f"Resumed image size from checkpoint: {self.image_size_yolo}")
             else:
                 logger.info("No checkpoint found (last.pt), starting fresh training.")
                 show_info("No checkpoint found — starting fresh.")
         
-        if not self.resume_training:
+        if not self.resume_training and not self.init_from_checkpoint:
             index_model_list = self.w.yolomodel_list.currentIndex()
             if index_model_list == 0:
                 show_warning("Please select a YOLO model")

--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -658,7 +658,12 @@ class YoloHandler(QObject):
                 if 'imgsz' not in train_args:
                     show_warning("Checkpoint does not contain image size info. Cannot continue from checkpoint.")
                     return
-                self.image_size_yolo = int(train_args['imgsz'])
+                # ultralytics stores imgsz as an int or occasionally as a list
+                # (e.g. [640]) depending on version — handle both.
+                _raw_imgsz = train_args['imgsz']
+                if isinstance(_raw_imgsz, (list, tuple)):
+                    _raw_imgsz = _raw_imgsz[0]
+                self.image_size_yolo = int(_raw_imgsz)
                 if self.image_size_yolo <= 0:
                     # imgsz was corrupted (e.g. by a previous bad resume) —
                     # recompute it from the actual training images so the scale

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1110,7 +1110,57 @@ class YOLO_octron:
             args = None
         
         return args
-    
+
+    @staticmethod
+    def _find_train_image_size(data_path, max_samples=500):
+        """
+        Find whether rectangular or square training images are used.
+        This determines the rect parameter and the correct imgsz for YOLO training.
+
+        Samples up to *max_samples* images across all subdirectories so that
+        the decision is robust even when multiple datasets contribute images
+        with different aspect ratios.
+
+        Returns
+        -------
+        height : float
+            Average height of the sampled images.
+        width : float
+            Average width of the sampled images.
+        rect : bool
+            True only if ALL sampled images are landscape (width > height).
+            False otherwise — including mixed or portrait datasets — because
+            of an ultralytics dataloader bug that does not permit rectangular
+            (non-square) batches when height > width.
+            TODO: Re-evaluate this with updates of ultralytics. Current version: 8.3.158
+        """
+        data_path = Path(data_path)
+        assert data_path.exists(), f"Data path {data_path} does not exist."
+        png_files = list(data_path.glob('**/*.png'))
+        if len(png_files) == 0:
+            raise FileNotFoundError(f"No .png files found in {data_path.as_posix()}")
+        logger.debug(f'Found {len(png_files)} png files')
+        samples = random.sample(png_files, min(max_samples, len(png_files)))
+
+        widths, heights = [], []
+        for fpath in samples:
+            # Read width/height directly from PNG IHDR chunk (bytes 16-23)
+            # PIL.Image.open() per file is very slow for large datasets.
+            with open(fpath, 'rb') as f:
+                f.seek(16)
+                w, h = struct.unpack('>II', f.read(8))
+            widths.append(w)
+            heights.append(h)
+
+        avg_h = sum(heights) / len(heights)
+        avg_w = sum(widths) / len(widths)
+
+        # rect=True only when EVERY sampled image is landscape.
+        # Any portrait or square image forces rect=False (ultralytics bug).
+        all_landscape = all(w > h for w, h in zip(widths, heights))
+        rect = all_landscape
+
+        return avg_h, avg_w, rect
 
     def train(self, 
               device='cpu',
@@ -1209,58 +1259,7 @@ class YOLO_octron:
                 'remaining_time': 0,
                 'finish_time': time.time(),
             })
-        
-        def _find_train_image_size(data_path, max_samples=500): 
-            """
-            Helper to find whether rectangular or square training images are used.
-            This determines rect parameter in YOLO training.
-            
-            Samples up to *max_samples* images across all subdirectories so that
-            the decision is robust even when multiple datasets contribute images
-            with different aspect ratios.
-            
-            Returns 
-            -------
-            height : float
-                Average height of the sampled images.
-            width : float
-                Average width of the sampled images.
-            rect : bool
-                True only if ALL sampled images are landscape (width > height).
-                False otherwise — including mixed or portrait datasets — because
-                of an ultralytics dataloader bug that does not permit rectangular
-                (non-square) batches when height > width.
-                TODO: Re-evaluate this with updates of ultralytics. Current version: 8.3.158
-            """
-            data_path = Path(data_path)
-            assert data_path.exists(), f"Data path {data_path} does not exist."
-            png_files = list(data_path.glob('**/*.png'))
-            if len(png_files) == 0:
-                raise FileNotFoundError(f"No .png files found in {data_path.as_posix()}")
-            logger.debug(f'Found {len(png_files)} png files')
-            samples = random.sample(png_files, min(max_samples, len(png_files)))
-
-            widths, heights = [], []
-            for fpath in samples:
-                # Read width/height directly from PNG IHDR chunk (bytes 16-23)
-                # I had it on PIL.Image.open() per file first, but this is very slow ... 
-                with open(fpath, 'rb') as f:
-                    f.seek(16)
-                    w, h = struct.unpack('>II', f.read(8))
-                widths.append(w)
-                heights.append(h)
-            
-            avg_h = sum(heights) / len(heights)
-            avg_w = sum(widths) / len(widths)
-            
-            # rect=True only when EVERY sampled image is landscape.
-            # Any portrait or square image forces rect=False (ultralytics bug).
-            all_landscape = all(w > h for w, h in zip(widths, heights))
-            rect = all_landscape
-            
-            return avg_h, avg_w, rect
-
-        # Remove any stale ultralytics disk-cache .npy files from the training
+        # Remove any stale ultralytics disk-cache .npy files
         # data directory before starting.  ultralytics cache='disk' writes
         # <stem>.npy files alongside source images, and BaseDataset.load_image
         # will silently load any matching .npy it finds — even when cache='disk'
@@ -1288,7 +1287,7 @@ class YOLO_octron:
         if device == 'mps':
             logger.warning("MPS is not yet fully supported in PyTorch. Use at your own risk.")
         
-        assert imagesz % 32 == 0, 'YOLO image size must be a multiple of 32'
+        assert imagesz > 0 and imagesz % 32 == 0, 'YOLO image size must be a positive multiple of 32'
         # Start training in a separate thread
         training_complete = threading.Event()
         training_error = None
@@ -1298,7 +1297,7 @@ class YOLO_octron:
             # overlap_mask - https://github.com/ultralytics/ultralytics/issues/3213#issuecomment-2799841153
             nonlocal training_error
             try:
-                img_height, img_width, rect = _find_train_image_size(self.data_path)
+                img_height, img_width, rect = self._find_train_image_size(self.data_path)
                 # Start training
                 logger.info(f"Starting training for {epochs} epochs...")
                 logger.info(f"Setting rect={rect} based on training image size of {img_width}x{img_height} (wxh)")
@@ -1313,6 +1312,7 @@ class YOLO_octron:
                     device=device,
                     optimizer='auto',
                     rect=rect, # if square training images then rect=False 
+                    amp=True,
                     cos_lr=True,
                     fraction=1.0,
                     epochs=epochs,

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1132,7 +1132,8 @@ class YOLO_octron:
             False otherwise — including mixed or portrait datasets — because
             of an ultralytics dataloader bug that does not permit rectangular
             (non-square) batches when height > width.
-            TODO: Re-evaluate this with updates of ultralytics. Current version: 8.3.158
+            TODO: Re-evaluate this with updates of ultralytics. Current version: 8.4.48
+            (As of 8.4.48, the rect=portrait/square crash bug is still present.)
         """
         data_path = Path(data_path)
         assert data_path.exists(), f"Data path {data_path} does not exist."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "kornia>=0.8.0",
     "cmasher>=1.9.2",
     "imantics",
-    "ultralytics>=8.4.30",
+    "ultralytics>=8.4.33",
     "tensorboard>=2.19.0",
     "lap>=0.5.12",
     "opencv-python>=4.11.0",       

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "kornia>=0.8.0",
     "cmasher>=1.9.2",
     "imantics",
-    "ultralytics>=8.4.33",
+    "ultralytics>=8.4.46",
     "tensorboard>=2.19.0",
     "lap>=0.5.12",
     "opencv-python>=4.11.0",       


### PR DESCRIPTION
Fixes broken resume behavior when the "Resume" checkbox is checked after a completed or interrupted training run.

**Root cause**
The old code set imgsz=0 when resuming, expecting ultralytics to ignore it. It doesn't — ultralytics clamps it to [32], causing all training at 32×32 and zero losses (see ultralytics issue #24046).

**Changes**
•  Completed runs (epoch == -1): instead of aborting with an error, a new training run is initialized from last.pt weights (init_from_checkpoint path, resume=False). The model continues training for the requested number of epochs.
•  Interrupted runs (epoch != -1): strict resume proceeds as before, but imgsz is now correctly read from checkpoint['train_args'] rather than hard-coded to 0. A fallback recomputes imgsz from the training images if the stored value is corrupt (<= 0) or stored as a list.
•  _find_train_image_size refactored to a static method so it can be called from both the training pipeline and the checkpoint recovery path.
•  amp=True added explicitly to training kwargs.
•  ultralytics>=8.4.46 required: 8.4.33 fixed the YOLO26 loss-criterion restore on resume; 8.4.46 adds a resume safety guard for completed checkpoints and a multi-scale training minimum-size clamp.