### PR TITLE
Accept tif stacks in reader conversion to mp4

### DIFF
--- a/octron/reader.py
+++ b/octron/reader.py
@@ -80,8 +80,8 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
     
     
     # Case D 
-    # Check if the folder has any kind of video or mj2 files 
-    video_formats = [".avi", ".mov", ".mj2", ".mpg", ".mpeg", ".mjpeg", ".mjpg", ".wmv", ".mp4", ".mkv", ".mts"]
+    # Check if the folder has any kind of video or multi-frame TIFF files
+    video_formats = [".avi", ".mov", ".mj2", ".mpg", ".mpeg", ".mjpeg", ".mjpg", ".wmv", ".mp4", ".mkv", ".mts", ".tif", ".tiff"]
     video_formats.extend([fmt.upper() for fmt in video_formats])
     
     # Find all video files in the folder
@@ -93,7 +93,7 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
 
     # If we found video files, offer to transcode them
     if video_files:
-        logger.info(f"Found {len(video_files)} video files in {path}")
+        logger.info(f"Found {len(video_files)} transcodable files in {path}")
         
         # Create a dialog for transcoding options
         from qtpy.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, 
@@ -108,7 +108,7 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
         layout = QVBoxLayout()
         
         # Add description
-        layout.addWidget(QLabel(f"Found {len(video_files)} videos. Select which to transcode to mp4:"))
+        layout.addWidget(QLabel(f"Found {len(video_files)} inputs. Select which to transcode to mp4:"))
         
         # Add file list with multi-selection
         file_list = QListWidget()
@@ -195,7 +195,7 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
             selected_videos = [item.data(Qt.UserRole) for item in selected_items]
             
             if not selected_videos:
-                logger.info("No videos selected for transcoding.")
+                logger.info("No inputs selected for transcoding.")
                 return [(None,)]
             
             # Create output folder if needed
@@ -205,13 +205,16 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
             else:
                 output_folder = path
                 
-            logger.info(f"Transcoding {len(selected_videos)} videos to MP4 (CRF: {crf_value})...")
+            logger.info(f"Transcoding {len(selected_videos)} inputs to MP4 (CRF: {crf_value})...")
             
-            # Process one video at a time
+            # Process one input at a time
             successful = 0
             for i, video_path in enumerate(selected_videos, 1):
-                logger.info(f"Processing {i}/{len(selected_videos)}: {video_path.name}")
+                is_tiff = video_path.suffix.lower() in {".tif", ".tiff"}
+                input_label = video_path.name
                 output_path = output_folder / f"{video_path.stem}.mp4"
+
+                logger.info(f"Processing {i}/{len(selected_videos)}: {input_label}")
                 
                 # Check if file exists and overwrite is not selected
                 if not overwrite_existing and output_path.exists():
@@ -219,38 +222,106 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                     continue
 
                 # Define FFmpeg command
-                cmd = [
-                    "ffmpeg", "-i", str(video_path), 
-                    "-c:v", "libx264", "-preset", "superfast", 
-                    "-crf", str(crf_value),
-                    "-c:a", "aac", "-b:a", "128k",  # Audio settings
-                    str(output_path),
-                ]
+                if is_tiff:
+                    try:
+                        import numpy as np
+                        import tifffile
+                    except ImportError as e:
+                        logger.error(f"TIFF transcoding requires numpy+tifffile: {e}")
+                        continue
+
+                    stack = tifffile.imread(str(video_path))
+                    if stack.ndim == 2:
+                        stack = stack[np.newaxis, ...]
+
+                    # Accept grayscale (T,H,W) and RGB(A) (T,H,W,C) only.
+                    if stack.ndim == 3:
+                        if stack.dtype != np.uint8:
+                            smin, smax = stack.min(), stack.max()
+                            if smax > smin:
+                                stack = ((stack - smin) / (smax - smin) * 255).astype(np.uint8)
+                            else:
+                                stack = np.zeros_like(stack, dtype=np.uint8)
+                        stack = np.repeat(stack[..., np.newaxis], 3, axis=-1)
+                    elif stack.ndim == 4 and stack.shape[-1] in (3, 4):
+                        if stack.shape[-1] == 4:
+                            stack = stack[..., :3]
+                        if stack.dtype != np.uint8:
+                            smin, smax = stack.min(), stack.max()
+                            if smax > smin:
+                                stack = ((stack - smin) / (smax - smin) * 255).astype(np.uint8)
+                            else:
+                                stack = np.zeros_like(stack, dtype=np.uint8)
+                    else:
+                        logger.error(f"Unsupported TIFF shape for video conversion: {stack.shape}")
+                        continue
+
+                    frame_count, height, width, _ = stack.shape
+                    logger.info(f"Detected TIFF stack with {frame_count} frame(s): {video_path.name}")
+                    if frame_count < 2:
+                        logger.warning(f"'{video_path.name}' has only one frame; output will be a single-frame video.")
+
+                    cmd = [
+                        "ffmpeg",
+                        "-f", "rawvideo",
+                        "-pixel_format", "rgb24",
+                        "-video_size", f"{width}x{height}",
+                        "-framerate", "30",
+                        "-i", "-",
+                        "-c:v", "libx264", "-preset", "superfast",
+                        "-crf", str(crf_value),
+                        "-an",
+                        "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+                        str(output_path),
+                    ]
+                else:
+                    cmd = [
+                        "ffmpeg", "-i", str(video_path),
+                        "-c:v", "libx264", "-preset", "superfast",
+                        "-crf", str(crf_value),
+                        "-an",  # Disable audio for all outputs
+                        "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+                        str(output_path),
+                    ]
                 if overwrite_existing:
                     cmd.append("-y") # Overwrite output if it exists
                 
                 # Time the transcoding process
                 start_time = time.time()
                 try:
-                    subprocess.run(
-                        cmd, 
-                        stdout=subprocess.PIPE, 
-                        stderr=subprocess.PIPE, 
-                        check=True
-                    )
+                    if is_tiff:
+                        result = subprocess.run(
+                            cmd,
+                            input=stack.tobytes(),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True,
+                        )
+                    else:
+                        result = subprocess.run(
+                            cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            check=True,
+                        )
                     elapsed_time = time.time() - start_time
                     # Calculate file sizes for comparison
-                    input_size = video_path.stat().st_size / (1024 * 1024)  # MB
+                    input_bytes = video_path.stat().st_size
+                    input_size = input_bytes / (1024 * 1024)  # MB
                     output_size = output_path.stat().st_size / (1024 * 1024)  # MB
                     size_reduction = 100 * (1 - output_size / input_size) if input_size > 0 else 0
                     
                     logger.info(f"Successfully transcoded in {elapsed_time:.2f} seconds | Input: {input_size:.2f} MB, Output: {output_size:.2f} MB ({size_reduction:.1f}%)")
                     successful += 1
                 except subprocess.CalledProcessError as e:
-                    logger.error(f"Failed: {str(e)}")
+                    stderr_msg = e.stderr.decode("utf-8", errors="ignore").strip()
+                    if stderr_msg:
+                        logger.error(f"Failed: {stderr_msg.splitlines()[-1]}")
+                    else:
+                        logger.error(f"Failed: {str(e)}")
             
             # Report final results
-            logger.info(f"Successfully transcoded {successful}/{len(selected_videos)} videos")
+            logger.info(f"Successfully transcoded {successful}/{len(selected_videos)} inputs")
         
         return [(None,)]
     

--- a/octron/reader.py
+++ b/octron/reader.py
@@ -96,8 +96,8 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
         logger.info(f"Found {len(video_files)} transcodable files in {path}")
         
         # Create a dialog for transcoding options
-        from qtpy.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, 
-                                   QCheckBox, QSpinBox, QPushButton, QListWidget,
+        from qtpy.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+                                   QCheckBox, QSpinBox, QDoubleSpinBox, QPushButton, QListWidget,
                                    QDialogButtonBox, QAbstractItemView, QListWidgetItem,
                                    )
         from qtpy.QtCore import QSize, Qt
@@ -156,7 +156,29 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
         options_layout.addLayout(crf_layout)
         
         layout.addLayout(options_layout)
-        
+
+        # Framerate option
+        fps_layout = QHBoxLayout()
+        fps_check = QCheckBox("Set output framerate (fps):")
+        fps_check.setChecked(False)
+        fps_check.setToolTip(
+            "Override output framerate.\n"
+            "Videos: uses source fps when unchecked.\n"
+            "TIFFs: defaults to 20 fps when unchecked."
+        )
+        fps_layout.addWidget(fps_check)
+        fps_spin = QDoubleSpinBox()
+        fps_spin.setRange(1.0, 240.0)
+        fps_spin.setValue(20.0)
+        fps_spin.setSingleStep(1.0)
+        fps_spin.setDecimals(3)
+        fps_spin.setMinimumSize(QSize(80, 25))
+        fps_spin.setMaximumSize(QSize(80, 25))
+        fps_spin.setEnabled(False)
+        fps_check.toggled.connect(fps_spin.setEnabled)
+        fps_layout.addWidget(fps_spin)
+        layout.addLayout(fps_layout)
+
         # Add buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         layout.addWidget(button_box)
@@ -189,6 +211,8 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
             create_subfolder = subfolder_check.isChecked()
             crf_value = crf_spin.value()
             overwrite_existing = overwrite_check.isChecked()
+            use_custom_fps = fps_check.isChecked()
+            fps_value = fps_spin.value() if use_custom_fps else None
             
             # Get selected videos using selectedItems() for reliability
             selected_items = file_list.selectedItems()
@@ -230,43 +254,116 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                         logger.error(f"TIFF transcoding requires numpy+tifffile: {e}")
                         continue
 
-                    stack = tifffile.imread(str(video_path))
-                    if stack.ndim == 2:
-                        stack = stack[np.newaxis, ...]
+                    def _to_uint8(arr: "np.ndarray") -> "np.ndarray":
+                        """Normalise array to uint8, preserving relative intensities."""
+                        if arr.dtype == np.uint8:
+                            return arr
+                        smin, smax = float(arr.min()), float(arr.max())
+                        if smax > smin:
+                            return ((arr.astype(np.float32) - smin) / (smax - smin) * 255).astype(np.uint8)
+                        return np.zeros_like(arr, dtype=np.uint8)
 
-                    # Accept grayscale (T,H,W) and RGB(A) (T,H,W,C) only.
-                    if stack.ndim == 3:
-                        if stack.dtype != np.uint8:
-                            smin, smax = stack.min(), stack.max()
-                            if smax > smin:
-                                stack = ((stack - smin) / (smax - smin) * 255).astype(np.uint8)
-                            else:
-                                stack = np.zeros_like(stack, dtype=np.uint8)
-                        stack = np.repeat(stack[..., np.newaxis], 3, axis=-1)
-                    elif stack.ndim == 4 and stack.shape[-1] in (3, 4):
-                        if stack.shape[-1] == 4:
-                            stack = stack[..., :3]
-                        if stack.dtype != np.uint8:
-                            smin, smax = stack.min(), stack.max()
-                            if smax > smin:
-                                stack = ((stack - smin) / (smax - smin) * 255).astype(np.uint8)
-                            else:
-                                stack = np.zeros_like(stack, dtype=np.uint8)
-                    else:
-                        logger.error(f"Unsupported TIFF shape for video conversion: {stack.shape}")
+                    try:
+                        with tifffile.TiffFile(str(video_path)) as tif:
+                            series = tif.series[0]
+                            axes  = series.axes   # e.g. "TCYX", "TYX", "TZYXC"
+                            sizes = series.sizes  # e.g. {'T':100, 'C':2, 'Y':512, 'X':512}
+                            stack = series.asarray()
+                    except Exception as e:
+                        logger.error(f"Failed to read TIFF '{video_path.name}': {e}")
                         continue
 
+                    n_t = sizes.get('T', 0)
+                    n_z = sizes.get('Z', 0)
+                    n_c = sizes.get('C', 0)
+
+                    logger.info(
+                        f"TIFF detected: axes='{axes}' shape={stack.shape} dtype={stack.dtype} "
+                        f"| T={n_t} Z={n_z} C={n_c} "
+                        f"H={sizes.get('Y', '?')} W={sizes.get('X', '?')} "
+                        f"| {video_path.name}"
+                    )
+
+                    # Reject TIFFs with both a time AND a Z axis — ambiguous for video conversion
+                    if n_t > 0 and n_z > 0:
+                        logger.warning(
+                            f"Skipped '{video_path.name}': TIFF contains both a time axis "
+                            f"(T={n_t}) and a Z axis (Z={n_z}) (axes='{axes}'). "
+                            f"Cannot determine intended frame order for video conversion."
+                        )
+                        continue
+
+                    # Reject single-frame / 2D-only images
+                    if n_t >= 2:
+                        frame_key = 'T'
+                        n_frames = n_t
+                    elif n_z >= 2:
+                        frame_key = 'Z'
+                        n_frames = n_z
+                        logger.info(f"No time axis; treating Z-stack ({n_z} slices) as frames.")
+                    else:
+                        logger.warning(
+                            f"Skipped '{video_path.name}': single-frame or 2D TIFF "
+                            f"(axes='{axes}'). Only multi-frame TIFFs are supported."
+                        )
+                        continue
+
+                    # Reorder axes to canonical order:
+                    # (frame_key, [unknown extras,] [C,] Y, X)
+                    axes_list = list(axes)
+                    known = {'T', 'Z', 'C', 'Y', 'X'}
+                    extra = [a for a in axes_list if a not in known]
+
+                    target_order = [frame_key] + extra + (['C'] if n_c > 0 else []) + ['Y', 'X']
+
+                    perm = [axes_list.index(a) for a in target_order]
+                    if perm != list(range(stack.ndim)):
+                        stack = stack.transpose(perm)
+
+                    # Flatten any extra leading dims into the frames axis.
+                    # The last `trailing` dims are always (C,) Y, X.
+                    trailing = 3 if n_c > 0 else 2
+                    n_leading = stack.ndim - trailing
+                    if n_leading > 1:
+                        n_frames = int(np.prod(stack.shape[:n_leading]))
+                        stack = stack.reshape(n_frames, *stack.shape[n_leading:])
+                        logger.info(f"Flattened leading axes → {n_frames} frames.")
+
+                    # Move C from position 1 to last → (frames, Y, X, C)
+                    if n_c > 0:
+                        stack = np.moveaxis(stack, 1, -1)
+
+                    # Map channels to RGB (frames, Y, X, 3)
+                    if n_c == 0:
+                        # Grayscale: (frames, Y, X) → (frames, Y, X, 3)
+                        stack = _to_uint8(stack)
+                        stack = np.repeat(stack[..., np.newaxis], 3, axis=-1)
+                    elif n_c == 1:
+                        stack = _to_uint8(stack[..., 0])
+                        stack = np.repeat(stack[..., np.newaxis], 3, axis=-1)
+                    elif n_c == 2:
+                        # Map to R/G channels, B = 0
+                        stack = _to_uint8(stack)
+                        zeros = np.zeros((*stack.shape[:3], 1), dtype=np.uint8)
+                        stack = np.concatenate([stack, zeros], axis=-1)
+                        logger.info("2-channel TIFF mapped to R/G channels (B=0).")
+                    elif n_c == 3:
+                        stack = _to_uint8(stack)
+                    elif n_c == 4:
+                        stack = _to_uint8(stack[..., :3])  # drop alpha
+                    else:
+                        logger.warning(f"'{video_path.name}': {n_c} channels detected; using first 3 as RGB.")
+                        stack = _to_uint8(stack[..., :3])
+
                     frame_count, height, width, _ = stack.shape
-                    logger.info(f"Detected TIFF stack with {frame_count} frame(s): {video_path.name}")
-                    if frame_count < 2:
-                        logger.warning(f"'{video_path.name}' has only one frame; output will be a single-frame video.")
+                    logger.info(f"Transcoding {frame_count} frames ({width}×{height}) from '{video_path.name}'")
 
                     cmd = [
                         "ffmpeg",
                         "-f", "rawvideo",
                         "-pixel_format", "rgb24",
                         "-video_size", f"{width}x{height}",
-                        "-framerate", "30",
+                        "-framerate", str(fps_value) if fps_value is not None else "20",
                         "-i", "-",
                         "-c:v", "libx264", "-preset", "superfast",
                         "-crf", str(crf_value),
@@ -281,8 +378,10 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                         "-crf", str(crf_value),
                         "-an",  # Disable audio for all outputs
                         "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
-                        str(output_path),
                     ]
+                    if fps_value is not None:
+                        cmd += ["-r", str(fps_value)]
+                    cmd.append(str(output_path))
                 if overwrite_existing:
                     cmd.append("-y") # Overwrite output if it exists
                 

--- a/octron/reader.py
+++ b/octron/reader.py
@@ -162,9 +162,11 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
         fps_check = QCheckBox("Set output framerate (fps):")
         fps_check.setChecked(False)
         fps_check.setToolTip(
-            "Override output framerate.\n"
-            "Videos: uses source fps when unchecked.\n"
-            "TIFFs: defaults to 20 fps when unchecked."
+            "Set output framerate.\n"
+            "Videos: reinterprets source frames at this fps, changing playback speed\n"
+            "  (e.g. 10 fps source → 100 fps = plays 10x faster).\n"
+            "  Leave unchecked to keep original playback speed.\n"
+            "TIFFs: sets the playback fps of the output (default 20 fps)."
         )
         fps_layout.addWidget(fps_check)
         fps_spin = QDoubleSpinBox()
@@ -372,16 +374,19 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                         str(output_path),
                     ]
                 else:
-                    cmd = [
-                        "ffmpeg", "-i", str(video_path),
+                    # -r before -i reinterprets the source timestamps at the given fps,
+                    # changing playback speed without duplicating frames.
+                    cmd = ["ffmpeg"]
+                    if fps_value is not None:
+                        cmd += ["-r", str(fps_value)]
+                    cmd += [
+                        "-i", str(video_path),
                         "-c:v", "libx264", "-preset", "superfast",
                         "-crf", str(crf_value),
                         "-an",  # Disable audio for all outputs
                         "-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2,format=yuv420p",
+                        str(output_path),
                     ]
-                    if fps_value is not None:
-                        cmd += ["-r", str(fps_value)]
-                    cmd.append(str(output_path))
                 if overwrite_existing:
                     cmd.append("-y") # Overwrite output if it exists
                 

--- a/octron/reader.py
+++ b/octron/reader.py
@@ -231,7 +231,8 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
             else:
                 output_folder = path
                 
-            logger.info(f"Transcoding {len(selected_videos)} inputs to MP4 (CRF: {crf_value})...")
+            fps_info = f"{fps_value} fps" if fps_value is not None else "source fps (videos) / 20 fps (TIFFs)"
+            logger.info(f"Transcoding {len(selected_videos)} inputs to MP4 | CRF: {crf_value} | Framerate: {fps_info}")
             
             # Process one input at a time
             successful = 0
@@ -358,7 +359,11 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                         stack = _to_uint8(stack[..., :3])
 
                     frame_count, height, width, _ = stack.shape
-                    logger.info(f"Transcoding {frame_count} frames ({width}×{height}) from '{video_path.name}'")
+                    out_fps = fps_value if fps_value is not None else 20.0
+                    logger.info(
+                        f"Transcoding TIFF: {frame_count} frames ({width}\u00d7{height}) "
+                        f"@ {out_fps} fps | '{video_path.name}'"
+                    )
 
                     cmd = [
                         "ffmpeg",
@@ -374,6 +379,13 @@ def read_octron_folder(path: "Path") -> List["LayerData"]:
                         str(output_path),
                     ]
                 else:
+                    if fps_value is not None:
+                        logger.info(
+                            f"Transcoding video: source fps reinterpreted as {fps_value} fps "
+                            f"(faster playback) | '{video_path.name}'"
+                        )
+                    else:
+                        logger.info(f"Transcoding video: keeping source fps | '{video_path.name}'")
                     # -r before -i reinterprets the source timestamps at the given fps,
                     # changing playback speed without duplicating frames.
                     cmd = ["ffmpeg"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "scipy>=1.15.1",
     "pandas>=2.2.3",
     "scikit-image>=0.25.0",
+    "tifffile",
     "zarr>=3.1.2",
     "kornia>=0.8.0",
     "cmasher>=1.9.2",


### PR DESCRIPTION
Uses `tifffile` to parse multi page tif files and then pipe those to ffmpeg for conversion.

### Conversion details

| Axes                         | Description                               | Handling                               |
| ---------------------------- | ----------------------------------------- | -------------------------------------- |
| `YX`, `YXC`, `CYX`           | 2D single frame                           | Rejected                               |
| `TZYX`, `TZYXC`, etc.        | Time + Z-stack (any combination)          | Rejected                               |
| `TYX` / `ZYX`                | Time-lapse or Z-stack, grayscale          | → RGB                                  |
| `TCYX` / `TYXC`              | Time-lapse, channel-first or channel-last | reordered correctly                    |
| C=0 or C=1                   | Grayscale / single-channel                | → repeated to RGB                      |
| C=2                          | 2-channel fluorescence                    | → R/G channels, B=0                    |
| C=3                          | RGB                                       | used as-is                             |
| C=4                          | RGBA                                      | alpha dropped                          |
| C>4                          | Hyperspectral / multi-channel             | first 3 channels used as RGB           |
| `uint8`                      | 8-bit data                                | used as-is                             |
| `uint16` / `float32` / other | Higher bit-depth or float                 | normalised to uint8 via global min/max |

### New "framerate" setting that is applied to both video as well as tif conversion to .mp4
<img width="501" height="447" alt="Screenshot 2026-05-14 at 17 35 16" src="https://github.com/user-attachments/assets/7b5d140c-add5-43f8-918c-28e4e0ff9170" />

### More explicit logger output 

The log output will now look like this for a typical run:
```
Transcoding 5 inputs to MP4 | CRF: 23 | Framerate: 100.0 fps
Processing 1/5: media-4.mp4
Transcoding video: source fps reinterpreted as 100.0 fps (faster playback) | 'media-4.mp4'
Successfully transcoded in 1.23 seconds | Input: 8.45 MB, Output: 3.21 MB (62.0%)
Processing 2/5: stack.tif
TIFF detected: axes='TYX' shape=(358, 512, 512) dtype=uint16 | ...
Transcoding TIFF: 358 frames (512×512) @ 100.0 fps | 'stack.tif'
Successfully transcoded in 4.56 seconds | ...
```

And without a custom fps set:
```
Transcoding 5 inputs to MP4 | CRF: 23 | Framerate: source fps (videos) / 20 fps (TIFFs)
...
Transcoding video: keeping source fps | 'media-4.mp4'
```
