### PR TITLE
surface ffmpeg errors and add --encoder/--no-nvenc override

### DIFF
--- a/octron/cli.py
+++ b/octron/cli.py
@@ -369,6 +369,14 @@ def render(
         "draft", "--preset",
         help="Quality preset: 'preview' (0.25×), 'draft' (0.5×), 'final' (full resolution).",
     ),
+    encoder: str = typer.Option(
+        "auto", "--encoder",
+        help="Video encoder: 'auto' (prefer GPU h264_nvenc, else libx264), 'nvenc' (force GPU), or 'libx264' (force CPU).",
+    ),
+    no_nvenc: bool = typer.Option(
+        False, "--no-nvenc",
+        help="Force the CPU encoder (libx264); shorthand for --encoder libx264. Use if h264_nvenc fails (e.g. old NVIDIA driver).",
+    ),
     start: int = typer.Option(None, "--start", help="First frame to render (inclusive)."),
     end: int = typer.Option(None, "--end", help="Last frame to render (exclusive)."),
     # --- Overlay options ---
@@ -457,6 +465,18 @@ def render(
             f"preset must be one of {list(PRESETS)}.", param_hint="'--preset'"
         )
 
+    encoder = encoder.lower()
+    if encoder not in ("auto", "nvenc", "libx264"):
+        raise typer.BadParameter(
+            "must be one of 'auto', 'nvenc', 'libx264'.", param_hint="'--encoder'"
+        )
+    if no_nvenc:
+        if encoder == "nvenc":
+            raise typer.BadParameter(
+                "conflicts with '--encoder nvenc'.", param_hint="'--no-nvenc'"
+            )
+        encoder = "libx264"
+
     # Resolve mode-specific defaults: overlay → everything on; tracklets → nothing on
     if tracklets:
         resolved_masks = draw_masks if draw_masks is not None else False
@@ -515,6 +535,7 @@ def render(
         trim=trim,
         skip_empty=skip_empty,
         min_confidence=min_confidence,
+        encoder=encoder,
         debug=debug,
     )
 

--- a/octron/tools/_ffmpeg.py
+++ b/octron/tools/_ffmpeg.py
@@ -12,6 +12,7 @@ CLI, the GUI reader, and core.
 
 import shutil
 import subprocess
+import tempfile
 
 
 # Even-dimension + yuv420p filter.
@@ -99,3 +100,117 @@ def h264_codec_args(encoder, crf=23, preset="superfast"):
     if encoder == "h264_nvenc":
         return ["-c:v", "h264_nvenc", "-preset", "p4", "-cq", str(crf)]
     return ["-c:v", "libx264", "-preset", preset, "-crf", str(crf)]
+
+
+def resolve_encoder(encoder="auto", prefer_hardware=True):
+    """Resolve an encoder choice to a concrete ffmpeg encoder name.
+
+    ``encoder`` is ``'auto'`` (defer to :func:`detect_h264_encoder`),
+    ``'nvenc'``/``'h264_nvenc'`` (force the GPU encoder), or ``'libx264'``
+    (force the CPU encoder).
+    """
+    e = (encoder or "auto").lower()
+    if e in ("auto", ""):
+        return detect_h264_encoder(prefer_hardware=prefer_hardware)
+    if e in ("nvenc", "h264_nvenc"):
+        return "h264_nvenc"
+    if e in ("libx264", "x264", "cpu"):
+        return "libx264"
+    raise ValueError(
+        f"Unknown encoder {encoder!r}; choose from 'auto', 'nvenc', 'libx264'."
+    )
+
+
+class _FfmpegWriter:
+    """Raw-video -> ffmpeg pipe writer that surfaces ffmpeg's own errors.
+
+    ffmpeg's stderr is redirected to a temporary file (never an unread PIPE,
+    which could deadlock a long encode); on failure its tail is read into the
+    raised error. ``write`` turns a dead-ffmpeg pipe (BrokenPipeError, or
+    Windows' OSError EINVAL) into a clear RuntimeError instead of an opaque OS
+    error, and ``close`` reports a non-zero ffmpeg exit. The process and temp
+    file are always cleaned up (``__del__`` is a safety net so a caller error
+    cannot leak them).
+    """
+
+    def __init__(self, proc, stderr_file, encoder, output_path):
+        self._proc = proc
+        self._stderr_file = stderr_file
+        self._encoder = encoder
+        self._output_path = str(output_path)
+        self._closed = False
+
+    def _stderr_tail(self, limit=2000):
+        try:
+            self._stderr_file.flush()
+            self._stderr_file.seek(0)
+            data = self._stderr_file.read()
+            if isinstance(data, bytes):
+                data = data.decode("utf-8", "replace")
+            data = data.strip()
+            return data[-limit:] if data else ""
+        except Exception:
+            return ""
+
+    def _nvenc_hint(self):
+        if self._encoder == "h264_nvenc":
+            return (
+                " The GPU encoder h264_nvenc failed to start -- your NVIDIA driver "
+                "may be too old for this ffmpeg build, or NVENC is unavailable. "
+                "Retry with '--no-nvenc' (or '--encoder libx264')."
+            )
+        return ""
+
+    def write(self, data):
+        try:
+            self._proc.stdin.write(data)
+        except (BrokenPipeError, OSError):
+            # ffmpeg exited early: broken pipe on POSIX, OSError EINVAL on Windows.
+            tail = self._stderr_tail()
+            self.close(check=False)
+            msg = (
+                f"ffmpeg exited before all frames were written "
+                f"(encoder={self._encoder}, output={self._output_path})."
+            )
+            if tail:
+                msg += f"\n--- ffmpeg output ---\n{tail}"
+            raise RuntimeError(msg + self._nvenc_hint())
+
+    def close(self, check=True):
+        if self._closed:
+            return None
+        self._closed = True
+        proc = self._proc
+        try:
+            if proc.stdin is not None and not proc.stdin.closed:
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+            rc = proc.wait()
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            rc = proc.poll()
+        tail = self._stderr_tail()
+        try:
+            self._stderr_file.close()
+        except Exception:
+            pass
+        if check and rc not in (0, None):
+            msg = (
+                f"ffmpeg exited with code {rc} "
+                f"(encoder={self._encoder}, output={self._output_path})."
+            )
+            if tail:
+                msg += f"\n--- ffmpeg output ---\n{tail}"
+            raise RuntimeError(msg + self._nvenc_hint())
+        return rc
+
+    def __del__(self):
+        try:
+            self.close(check=False)
+        except Exception:
+            pass

--- a/octron/tools/render.py
+++ b/octron/tools/render.py
@@ -12,9 +12,10 @@ report_bbox_sizes : Report bounding-box sizes to help choose tracklet crop size.
 """
 
 import subprocess
+import tempfile
 from pathlib import Path
 
-from octron.tools._ffmpeg import detect_h264_encoder, h264_codec_args, EVEN_DIM_YUV420P
+from octron.tools._ffmpeg import h264_codec_args, EVEN_DIM_YUV420P, resolve_encoder, _FfmpegWriter
 
 PRESETS = {
     "preview": {"scale": 0.25},
@@ -90,7 +91,12 @@ def _select_render_frames(per_track_frames, frame_start, frame_end):
 # ---------------------------------------------------------------------------
 
 def _open_ffmpeg_writer(output_path, fps, width, height, encoder):
-    """Open an ffmpeg subprocess pipe for encoding. Returns a Popen object."""
+    """Open an ffmpeg subprocess pipe for encoding. Returns a _FfmpegWriter.
+
+    ffmpeg's stderr is captured to a temp file (via the writer) so that if
+    ffmpeg exits early -- e.g. h264_nvenc can't initialise -- the real reason is
+    surfaced instead of an opaque broken-pipe error on the first frame write.
+    """
     codec_args = h264_codec_args(encoder, crf=20, preset="fast")
     # Apply the shared even-dimension + yuv420p filter (mirrors transcode.py).
     # Without it, encoding rgb24 input defaults to yuv444p (4:4:4), which macOS
@@ -98,7 +104,7 @@ def _open_ffmpeg_writer(output_path, fps, width, height, encoder):
     # (e.g. the 47px auto tracklet size) compound the problem. The filter rounds
     # each dimension down to even and converts to the widely-playable 4:2:0.
     cmd = [
-        "ffmpeg", "-y",
+        "ffmpeg", "-y", "-nostats", "-loglevel", "warning",
         "-f", "rawvideo", "-vcodec", "rawvideo",
         "-pix_fmt", "rgb24",
         "-s", f"{width}x{height}",
@@ -106,7 +112,10 @@ def _open_ffmpeg_writer(output_path, fps, width, height, encoder):
         "-i", "pipe:0",
         "-vf", EVEN_DIM_YUV420P,
     ] + codec_args + [str(output_path)]
-    return subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    # stderr -> temp file (not an unread PIPE, which could deadlock the encode).
+    stderr_file = tempfile.TemporaryFile(mode="w+b")
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=stderr_file)
+    return _FfmpegWriter(proc, stderr_file, encoder, output_path)
 
 
 class _MaskPrefetchError:
@@ -283,6 +292,7 @@ def run_tracklets(
     trim=False,
     skip_empty=False,
     min_confidence=0.5,
+    encoder="auto",
     debug=False,
 ):
     """
@@ -517,7 +527,7 @@ def run_tracklets(
         track_colors[tid] = (r, g, b)  # RGB to match FastVideoReader frames
 
     # One ffmpeg pipe per tracklet (replaces cv2.VideoWriter).
-    _encoder = detect_h264_encoder()
+    _encoder = resolve_encoder(encoder)
     logger.info(f"Encoder:  {_encoder} (ffmpeg)")
     writers = {}
     for tid in render_tids:
@@ -720,7 +730,7 @@ def run_tracklets(
                         crop[:] = 0
             else:
                 crop = np.zeros((size, size, 3), dtype=np.uint8)
-            writers[tid].stdin.write(np.ascontiguousarray(crop).tobytes())
+            writers[tid].write(np.ascontiguousarray(crop).tobytes())
 
         if debug:
             _t4 = time.perf_counter()
@@ -757,8 +767,7 @@ def run_tracklets(
 
     print()  # close the \r progress line
     for w in writers.values():
-        w.stdin.close()
-        w.wait()
+        w.close()
     logger.info(f"Tracklet(s) saved → {output_path}")
 
 
@@ -787,6 +796,7 @@ def run_render(
     draw_labels=True,
     start=None,
     end=None,
+    encoder="auto",
     debug=False,
 ):
     """
@@ -862,6 +872,7 @@ def run_render(
             trim=trim,
             skip_empty=skip_empty,
             min_confidence=min_confidence,
+            encoder=encoder,
             debug=debug,
         )
         return
@@ -959,11 +970,11 @@ def run_render(
     else:
         frames_to_render = range(frame_start, frame_end)
 
-    # Detect best encoder and open the ffmpeg writer
+    # Resolve the encoder (honours --encoder/--no-nvenc) and open the ffmpeg writer
     overlay_out = output_path / f"overlay_{preset}.mp4"
-    _encoder = detect_h264_encoder()
+    _encoder = resolve_encoder(encoder)
     logger.info(f"Encoder:  {_encoder} (ffmpeg)")
-    _ffmpeg_proc = _open_ffmpeg_writer(overlay_out, fps, out_w, out_h, _encoder)
+    _ffmpeg_writer = _open_ffmpeg_writer(overlay_out, fps, out_w, out_h, _encoder)
 
     # Batch size for zarr mask reads.  100 frames balances first-frame latency
     # (~1–7s on network) against memory usage; the prefetch thread ensures the
@@ -1131,7 +1142,7 @@ def run_render(
             _t3 = time.perf_counter()
             _dbg_t_blend += _t3 - _t2
 
-        _ffmpeg_proc.stdin.write(np.ascontiguousarray(out_frame).tobytes())
+        _ffmpeg_writer.write(np.ascontiguousarray(out_frame).tobytes())
 
         if debug:
             _t4 = time.perf_counter()
@@ -1167,8 +1178,5 @@ def run_render(
         )
 
     print()
-    _ffmpeg_proc.stdin.close()
-    rc = _ffmpeg_proc.wait()
-    if rc != 0:
-        logger.warning(f"ffmpeg exited with code {rc} — output may be incomplete.")
+    _ffmpeg_writer.close()
     logger.info(f"Overlay saved → {overlay_out}")


### PR DESCRIPTION
When the chosen encoder (e.g. `h264_nvenc`) failed to initialise, ffmpeg exited immediately and OCTRON only hit a dead pipe on the first frame write, for example: "OSError: [Errno 22]" on Windows, while ffmpeg's real error was discarded (stderr=DEVNULL) and the subprocess leaked.

Add a `_FfmpegWriter` that captures ffmpeg stderr to a temp file and, on a broken pipe or non-zero exit, raises a clear RuntimeError including the ffmpeg output and an `NVENC/--no-nvenc` hint, always cleaning up the process. Add resolve_encoder() and an `--encoder {auto,nvenc,libx264}` option plus `--no-nvenc` shorthand so users can force CPU encoding when NVENC is unavailable.