### PR TITLE
Updates for Napari 0.8.0

### DIFF
--- a/octron/gui_elements.py
+++ b/octron/gui_elements.py
@@ -33,17 +33,31 @@ __version__ = version("octron")
 class Mp4DropWidget(QWidget):
     # Signal emitted when one or more mp4 files are dropped; sends list of file paths.
     fileDropped = Signal(list)
+
+    # Prompt shown when the drop area is ready to accept a video.
+    DEFAULT_TEXT = "🎥 Click, or drag and drop .MP4 file here"
     
     def __init__(self, parent=None, callback=None):
         super().__init__(parent)
         self.setAcceptDrops(True)
         self.callback = callback
         layout = QVBoxLayout(self)
-        self.label = QLabel("🎥 Click, or drag and drop .MP4 file here", self)
+        self.label = QLabel(self.DEFAULT_TEXT, self)
         self.label.setAlignment(Qt.AlignCenter)
+        self.label.setWordWrap(True)
         layout.addWidget(self.label)
         self.setLayout(layout)
         self._setup_styles()
+
+    def set_locked(self, locked, message=None):
+        """Lock (disable) or unlock (enable) the drop area.
+
+        When locked, the widget stops accepting drops and clicks and shows
+        ``message`` instead of the default prompt. When unlocked, it accepts
+        files again and restores the default prompt.
+        """
+        self.setEnabled(not locked)
+        self.label.setText(message if (locked and message) else self.DEFAULT_TEXT)
 
     def _setup_styles(self):
         self.setAutoFillBackground(True)
@@ -124,7 +138,7 @@ class octron_gui_elements(QWidget):
         self.octron.mainLayout.setSpacing(20)
         self.octron.mainLayout.setObjectName(u"mainLayout")
         self.octron.mainLayout.setSizeConstraint(QLayout.SizeConstraint.SetNoConstraint)
-        self.octron.mainLayout.setContentsMargins(0, 0, 0, 0)
+        self.octron.mainLayout.setContentsMargins(0, 10, 0, 0)
         self.octron.octron_logo = QLabel(self.octron.verticalLayoutWidget)
         self.octron.octron_logo.setObjectName(u"octron_logo")
         self.octron.octron_logo.setEnabled(True)
@@ -236,6 +250,32 @@ class octron_gui_elements(QWidget):
         self.octron.existing_data_table.setObjectName(u"existing_data_table")
         self.octron.existing_data_table.setMinimumSize(QSize(380, 180))
         self.octron.existing_data_table.setMaximumSize(QSize(380, 180))
+        self.octron.existing_data_table.setContextMenuPolicy(Qt.ContextMenuPolicy.DefaultContextMenu)
+        self.octron.existing_data_table.setAutoFillBackground(False)
+        self.octron.existing_data_table.setStyleSheet(u"QTableView {\n"
+"    background-color: transparent;\n"
+"    gridline-color: transparent;\n"
+"}\n"
+"QTableView::item {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"}\n"
+"QHeaderView {\n"
+"    background-color: transparent;\n"
+"}\n"
+"QHeaderView::section {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"    padding: 2px 4px;\n"
+"}\n"
+"QTableCornerButton::section {\n"
+"    background-color: transparent;\n"
+"}")
+        self.octron.existing_data_table.setFrameShape(QFrame.Shape.NoFrame)
+        self.octron.existing_data_table.setFrameShadow(QFrame.Shadow.Plain)
+        self.octron.existing_data_table.setLineWidth(1)
         self.octron.existing_data_table.setEditTriggers(QAbstractItemView.EditTrigger.AnyKeyPressed|QAbstractItemView.EditTrigger.EditKeyPressed|QAbstractItemView.EditTrigger.SelectedClicked)
         self.octron.existing_data_table.setProperty("showDropIndicator", False)
         self.octron.existing_data_table.setDragDropOverwriteMode(False)
@@ -248,7 +288,8 @@ class octron_gui_elements(QWidget):
         self.octron.existing_data_table.horizontalHeader().setCascadingSectionResizes(True)
         self.octron.existing_data_table.horizontalHeader().setMinimumSectionSize(85)
         self.octron.existing_data_table.horizontalHeader().setDefaultSectionSize(85)
-        self.octron.existing_data_table.horizontalHeader().setHighlightSections(False)
+        self.octron.existing_data_table.horizontalHeader().setHighlightSections(True)
+        self.octron.existing_data_table.horizontalHeader().setStretchLastSection(True)
         self.octron.existing_data_table.verticalHeader().setVisible(False)
         self.octron.existing_data_table.verticalHeader().setMinimumSectionSize(20)
         self.octron.existing_data_table.verticalHeader().setDefaultSectionSize(20)
@@ -514,7 +555,7 @@ class octron_gui_elements(QWidget):
         self.octron.train_tab.setSizePolicy(sizePolicy1)
         self.octron.verticalLayoutWidget_4 = QWidget(self.octron.train_tab)
         self.octron.verticalLayoutWidget_4.setObjectName(u"verticalLayoutWidget_4")
-        self.octron.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 475))
+        self.octron.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 461))
         self.octron.train_vertical_layout = QVBoxLayout(self.octron.verticalLayoutWidget_4)
         self.octron.train_vertical_layout.setSpacing(20)
         self.octron.train_vertical_layout.setObjectName(u"train_vertical_layout")

--- a/octron/main.py
+++ b/octron/main.py
@@ -935,9 +935,12 @@ class octron_widget(QWidget):
             # Configure the table appearance
             # Prevent resizing of table columns by disabling interactive resizing
             header = self.existing_data_table.horizontalHeader()
-            header.setSectionResizeMode(QHeaderView.Fixed)
             header.setSectionsMovable(False)
-            header.setStretchLastSection(True)
+            header.setStretchLastSection(False)
+            # "Folder name" stretches to fill; the rest auto-size to their contents.
+            header.setSectionResizeMode(0, QHeaderView.Stretch)
+            for _col in range(1, self.label_table_model.columnCount()):
+                header.setSectionResizeMode(_col, QHeaderView.ResizeToContents)
             # Connect double-click event on table rows 
             self.existing_data_table.doubleClicked.connect(self.on_label_table_double_clicked)
             # Enable right-click context menu
@@ -1330,6 +1333,8 @@ class octron_widget(QWidget):
                 self.annotate_layer_create_groupbox.setEnabled(False)
                 # Reset naming of annotation tab 
                 self.main_toolbox.setItemText(1, "Generate annotation data")
+                # Video layer removed -- re-enable the drop area for a new video.
+                self._update_video_drop_state()
             # Reset the flag 
             self.remove_current_layer = False
     
@@ -1436,9 +1441,27 @@ class octron_widget(QWidget):
             logger.debug(f"VIDEO LAYER >>> {layer_name}")
             self.main_toolbox.widget(1).setEnabled(True) 
             self.main_toolbox.setItemText(1, f"Generate annotation data for: {self.current_video_hash}")
+            # A video is now loaded -- lock the drop area until it is removed.
+            self._update_video_drop_state()
 
         return
         
+    def _update_video_drop_state(self):
+        """
+        Enable the project video-drop area only when no video layer exists.
+
+        A project holds one video at a time, so while a video layer is
+        displayed the drop area is disabled and its text tells the user to
+        delete the video layer before a new video can be added. Once the
+        video layer is removed, the drop area is re-enabled.
+        """
+        video_loaded = self.video_layer is not None
+        self.video_file_drop_widget.set_locked(
+            video_loaded,
+            message=("🎥 A video is loaded.\n"
+                     "Delete the video layer to add a new video."),
+        )
+
     def on_mp4_file_dropped_area(self, video_paths):
         """
         Adds video layer on freshly dropped mp4 file.

--- a/octron/qt_gui/octron.py
+++ b/octron/qt_gui/octron.py
@@ -30,7 +30,7 @@ class Ui_octron_widgetui(object):
         self.mainLayout.setSpacing(20)
         self.mainLayout.setObjectName(u"mainLayout")
         self.mainLayout.setSizeConstraint(QLayout.SizeConstraint.SetNoConstraint)
-        self.mainLayout.setContentsMargins(0, 0, 0, 0)
+        self.mainLayout.setContentsMargins(0, 10, 0, 0)
         self.octron_logo = QLabel(self.verticalLayoutWidget)
         self.octron_logo.setObjectName(u"octron_logo")
         self.octron_logo.setEnabled(True)
@@ -142,6 +142,32 @@ class Ui_octron_widgetui(object):
         self.existing_data_table.setObjectName(u"existing_data_table")
         self.existing_data_table.setMinimumSize(QSize(380, 180))
         self.existing_data_table.setMaximumSize(QSize(380, 180))
+        self.existing_data_table.setContextMenuPolicy(Qt.ContextMenuPolicy.DefaultContextMenu)
+        self.existing_data_table.setAutoFillBackground(False)
+        self.existing_data_table.setStyleSheet(u"QTableView {\n"
+"    background-color: transparent;\n"
+"    gridline-color: transparent;\n"
+"}\n"
+"QTableView::item {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"}\n"
+"QHeaderView {\n"
+"    background-color: transparent;\n"
+"}\n"
+"QHeaderView::section {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"    padding: 2px 4px;\n"
+"}\n"
+"QTableCornerButton::section {\n"
+"    background-color: transparent;\n"
+"}")
+        self.existing_data_table.setFrameShape(QFrame.Shape.NoFrame)
+        self.existing_data_table.setFrameShadow(QFrame.Shadow.Plain)
+        self.existing_data_table.setLineWidth(1)
         self.existing_data_table.setEditTriggers(QAbstractItemView.EditTrigger.AnyKeyPressed|QAbstractItemView.EditTrigger.EditKeyPressed|QAbstractItemView.EditTrigger.SelectedClicked)
         self.existing_data_table.setProperty("showDropIndicator", False)
         self.existing_data_table.setDragDropOverwriteMode(False)
@@ -154,7 +180,8 @@ class Ui_octron_widgetui(object):
         self.existing_data_table.horizontalHeader().setCascadingSectionResizes(True)
         self.existing_data_table.horizontalHeader().setMinimumSectionSize(85)
         self.existing_data_table.horizontalHeader().setDefaultSectionSize(85)
-        self.existing_data_table.horizontalHeader().setHighlightSections(False)
+        self.existing_data_table.horizontalHeader().setHighlightSections(True)
+        self.existing_data_table.horizontalHeader().setStretchLastSection(True)
         self.existing_data_table.verticalHeader().setVisible(False)
         self.existing_data_table.verticalHeader().setMinimumSectionSize(20)
         self.existing_data_table.verticalHeader().setDefaultSectionSize(20)
@@ -420,7 +447,7 @@ class Ui_octron_widgetui(object):
         self.train_tab.setSizePolicy(sizePolicy1)
         self.verticalLayoutWidget_4 = QWidget(self.train_tab)
         self.verticalLayoutWidget_4.setObjectName(u"verticalLayoutWidget_4")
-        self.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 475))
+        self.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 461))
         self.train_vertical_layout = QVBoxLayout(self.verticalLayoutWidget_4)
         self.train_vertical_layout.setSpacing(20)
         self.train_vertical_layout.setObjectName(u"train_vertical_layout")

--- a/octron/qt_gui/octron.ui
+++ b/octron/qt_gui/octron.ui
@@ -50,6 +50,9 @@
     <property name="sizeConstraint">
      <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
     </property>
+    <property name="topMargin">
+     <number>10</number>
+    </property>
     <item alignment="Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop">
      <widget class="QLabel" name="octron_logo">
       <property name="enabled">
@@ -381,6 +384,44 @@
                 <height>180</height>
                </size>
               </property>
+              <property name="contextMenuPolicy">
+               <enum>Qt::ContextMenuPolicy::DefaultContextMenu</enum>
+              </property>
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">QTableView {
+    background-color: transparent;
+    gridline-color: transparent;
+}
+QTableView::item {
+    background-color: transparent;
+    border: none;
+    border-bottom: 1px solid #555;
+}
+QHeaderView {
+    background-color: transparent;
+}
+QHeaderView::section {
+    background-color: transparent;
+    border: none;
+    border-bottom: 1px solid #555;
+    padding: 2px 4px;
+}
+QTableCornerButton::section {
+    background-color: transparent;
+}</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Shape::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Shadow::Plain</enum>
+              </property>
+              <property name="lineWidth">
+               <number>1</number>
+              </property>
               <property name="editTriggers">
                <set>QAbstractItemView::EditTrigger::AnyKeyPressed|QAbstractItemView::EditTrigger::EditKeyPressed|QAbstractItemView::EditTrigger::SelectedClicked</set>
               </property>
@@ -418,7 +459,10 @@
                <number>85</number>
               </attribute>
               <attribute name="horizontalHeaderHighlightSections">
-               <bool>false</bool>
+               <bool>true</bool>
+              </attribute>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
               </attribute>
               <attribute name="verticalHeaderVisible">
                <bool>false</bool>
@@ -1239,7 +1283,7 @@ This will delete the masks on the current frame but no other (already annotated)
           <x>0</x>
           <y>0</y>
           <width>402</width>
-          <height>475</height>
+          <height>461</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="train_vertical_layout" stretch="0,0,0">

--- a/octron/qt_gui/octron_corrected.py
+++ b/octron/qt_gui/octron_corrected.py
@@ -30,7 +30,7 @@ class Ui_octron_widgetui(object):
         self.octron.mainLayout.setSpacing(20)
         self.octron.mainLayout.setObjectName(u"mainLayout")
         self.octron.mainLayout.setSizeConstraint(QLayout.SizeConstraint.SetNoConstraint)
-        self.octron.mainLayout.setContentsMargins(0, 0, 0, 0)
+        self.octron.mainLayout.setContentsMargins(0, 10, 0, 0)
         self.octron.octron_logo = QLabel(self.octron.verticalLayoutWidget)
         self.octron.octron_logo.setObjectName(u"octron_logo")
         self.octron.octron_logo.setEnabled(True)
@@ -142,6 +142,32 @@ class Ui_octron_widgetui(object):
         self.octron.existing_data_table.setObjectName(u"existing_data_table")
         self.octron.existing_data_table.setMinimumSize(QSize(380, 180))
         self.octron.existing_data_table.setMaximumSize(QSize(380, 180))
+        self.octron.existing_data_table.setContextMenuPolicy(Qt.ContextMenuPolicy.DefaultContextMenu)
+        self.octron.existing_data_table.setAutoFillBackground(False)
+        self.octron.existing_data_table.setStyleSheet(u"QTableView {\n"
+"    background-color: transparent;\n"
+"    gridline-color: transparent;\n"
+"}\n"
+"QTableView::item {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"}\n"
+"QHeaderView {\n"
+"    background-color: transparent;\n"
+"}\n"
+"QHeaderView::section {\n"
+"    background-color: transparent;\n"
+"    border: none;\n"
+"    border-bottom: 1px solid #555;\n"
+"    padding: 2px 4px;\n"
+"}\n"
+"QTableCornerButton::section {\n"
+"    background-color: transparent;\n"
+"}")
+        self.octron.existing_data_table.setFrameShape(QFrame.Shape.NoFrame)
+        self.octron.existing_data_table.setFrameShadow(QFrame.Shadow.Plain)
+        self.octron.existing_data_table.setLineWidth(1)
         self.octron.existing_data_table.setEditTriggers(QAbstractItemView.EditTrigger.AnyKeyPressed|QAbstractItemView.EditTrigger.EditKeyPressed|QAbstractItemView.EditTrigger.SelectedClicked)
         self.octron.existing_data_table.setProperty("showDropIndicator", False)
         self.octron.existing_data_table.setDragDropOverwriteMode(False)
@@ -154,7 +180,8 @@ class Ui_octron_widgetui(object):
         self.octron.existing_data_table.horizontalHeader().setCascadingSectionResizes(True)
         self.octron.existing_data_table.horizontalHeader().setMinimumSectionSize(85)
         self.octron.existing_data_table.horizontalHeader().setDefaultSectionSize(85)
-        self.octron.existing_data_table.horizontalHeader().setHighlightSections(False)
+        self.octron.existing_data_table.horizontalHeader().setHighlightSections(True)
+        self.octron.existing_data_table.horizontalHeader().setStretchLastSection(True)
         self.octron.existing_data_table.verticalHeader().setVisible(False)
         self.octron.existing_data_table.verticalHeader().setMinimumSectionSize(20)
         self.octron.existing_data_table.verticalHeader().setDefaultSectionSize(20)
@@ -420,7 +447,7 @@ class Ui_octron_widgetui(object):
         self.octron.train_tab.setSizePolicy(sizePolicy1)
         self.octron.verticalLayoutWidget_4 = QWidget(self.octron.train_tab)
         self.octron.verticalLayoutWidget_4.setObjectName(u"verticalLayoutWidget_4")
-        self.octron.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 475))
+        self.octron.verticalLayoutWidget_4.setGeometry(QRect(0, 0, 402, 461))
         self.octron.train_vertical_layout = QVBoxLayout(self.octron.verticalLayoutWidget_4)
         self.octron.train_vertical_layout.setSpacing(20)
         self.octron.train_vertical_layout.setObjectName(u"train_vertical_layout")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "setuptools",
-    "napari==0.7.1",
+    "napari==0.8.0",
     "numpy>=2.1.0",
     "qtpy>=2.4.3",
     "torch>=2.5.1",
@@ -61,7 +61,7 @@ dependencies = [
 [project.optional-dependencies]
 pyqt5 = ["PyQt5>=5.15.11"]
 pyqt6 = ["PyQt6>=6.10.0"]
-all = ["napari[pyqt6]==0.7.1"]
+all = ["napari[pyqt6]==0.8.0"]
 dev = [
     "pytest>=7.0",
     "pytest-cov",


### PR DESCRIPTION
This pull request introduces several UI and usability improvements, mainly focused on the video drop area and the appearance of the data table, as well as updating the `napari` dependency. The changes enhance user feedback when loading videos, improve the look and feel of table widgets, and ensure compatibility with the latest version of a key dependency.

**Video drop area usability improvements:**

* Added a `set_locked` method and related logic to the `Mp4DropWidget` class, allowing the video drop area to be programmatically enabled or disabled with a custom message. The drop area is now automatically locked when a video is loaded and unlocked when the video layer is removed, providing clear instructions to the user. 

**Table widget appearance and behavior:**
* Improved the appearance of `existing_data_table` by applying a transparent stylesheet, removing borders, and customizing header and grid lines. 
* Multiple little layout fixes

**Napari version update:**
* Updated the required version of `napari` to `0.8.0` (from `0.7.1`) in both the main and optional dependencies to ensure compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-R30) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L64-R64)