### PR TITLE
fix(predict): split cross-class track IDs instead of raising

### DIFF
--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -2489,6 +2489,12 @@ class YOLO_octron:
             video = video_dict['video']
             tracking_df_dict = {}
             track_id_label_dict = {}
+            # Standard (multi-object) tracking maps each (boxmot track ID, label)
+            # pair to a stable OCTRON track ID (see the else-branch below), so a
+            # boxmot ID that is matched to different classes over time is split
+            # into separate, label-consistent tracklets instead of raising.
+            split_track_ids = {}
+            next_split_track_id = 1
             video_prediction_start = time.time()
             frame_start = time.time()
             all_ids = []
@@ -2633,21 +2639,21 @@ class YOLO_octron:
                             track_id = (max(current_ids) + 1) if current_ids else 1
                             track_id_label_dict[label] = track_id
                     else: 
-                        # ! Use 'track_id' as keys in track_id_label_dict
-                        # There can be multiple objects/track IDs per label
-                        if track_id in track_id_label_dict:
-                            label_ = track_id_label_dict[track_id]
-                            if label_ != label: 
-                                raise IndexError(f'Track ID {track_id} - labels do not match: LABEL {label_} =! {label}')
-                                # This happens in cases 
-                                # where the same track ID is assigned to different labels over time 
-                                # Assign a new track ID
-                                # Get the largest key + 1, or start at 1 if dict is empty
-                                # current_ids = list(track_id_label_dict.keys())
-                                # track_id = (max(current_ids) + 1) if current_ids else 1
-                                # track_id_label_dict[track_id] = label
-                        else:
-                            track_id_label_dict[track_id] = label   
+                        # There can be multiple objects/track IDs per label.
+                        # A boxmot track ID can be matched to detections of
+                        # different classes over its lifetime: boxmot associates
+                        # class-agnostically and overwrites a track's class on
+                        # every match, only preserving class identity when
+                        # per_class=True (which several trackers, incl.
+                        # BoostTrack, do not support). Map each
+                        # (boxmot track ID, label) pair to a stable OCTRON track
+                        # ID so a mid-track class change becomes a separate,
+                        # label-consistent tracklet instead of raising.
+                        pair_key = (track_id, label)
+                        if pair_key not in split_track_ids:
+                            split_track_ids[pair_key] = next_split_track_id
+                            next_split_track_id += 1
+                        track_id = split_track_ids[pair_key]
                         
                     # Take care of zarr array and tracking dataframe 
                     if not track_id in all_ids:

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -1156,12 +1156,16 @@ class YOLO_octron:
         if not hasattr(self, 'training_path') or self.training_path is None:
             pass
         else:
-            self.yolo_settings.update({
+            # Only update keys that exist in the installed ultralytics version —
+            # some keys (e.g. 'hub') have been removed in recent releases.
+            _desired = {
                 'sync': False,
-                'hub': False,
                 'tensorboard': True,
-                'runs_dir': self.training_path.as_posix()
-            })
+                'runs_dir': self.training_path.as_posix(),
+            }
+            _valid = {k: v for k, v in _desired.items() if k in self.yolo_settings}
+            if _valid:
+                self.yolo_settings.update(_valid)
         from ultralytics import YOLO   
         
         # Load specified model


### PR DESCRIPTION
A boxmot track ID can be matched to detections of different classes over time (boxmot associates class-agnostically and overwrites a track's class each match; per_class=True is unavailable for BoostTrack). predict_batch assumed one label per track ID and raised IndexError on a mismatch.

Map each (boxmot_track_id, label) pair to a stable OCTRON track ID so a mid-track class change becomes a separate, label-consistent tracklet.