### PR TITLE
Optimize training data splits

### DIFF
--- a/octron/_logging.py
+++ b/octron/_logging.py
@@ -9,6 +9,7 @@ output.
 import sys
 
 from loguru import logger
+from tqdm import tqdm
 
 from octron._version import version as octron_version
 
@@ -22,6 +23,19 @@ _LOG_FORMAT_DEBUG = (
     "<dim>{name}:{line}</dim> | "
     "{message}"
 )
+
+
+def _tqdm_safe_sink(message) -> None:
+    """Write a log record without corrupting active tqdm progress bars.
+
+    ``tqdm`` renders its bars with a carriage return on ``sys.stderr``.
+    A plain write to the same stream (a log line, a ``print``) does not
+    clear the bar first, so on refresh the bar "staircases" onto new
+    lines. Routing loguru through :meth:`tqdm.tqdm.write` clears any live
+    bar, emits the already-formatted (colorized, newline-terminated)
+    record, then redraws the bar on the next tick.
+    """
+    tqdm.write(message, end="", file=sys.stderr)
 
 
 def setup_logging(debug: bool = False) -> None:
@@ -42,8 +56,11 @@ def setup_logging(debug: bool = False) -> None:
     level = "DEBUG" if debug else "INFO"
     fmt = _LOG_FORMAT_DEBUG if debug else _LOG_FORMAT_NORMAL
 
+    # Route logs through tqdm.write so log lines never fracture an active
+    # progress bar (the bar is cleared, the record is written, then the bar
+    # is redrawn). colorize=True is kept so colours still render.
     logger.add(
-        sys.stderr,
+        _tqdm_safe_sink,
         level=level,
         format=fmt,
         colorize=True,

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -259,19 +259,23 @@ def split(
     train_mode: TrainMode = typer.Option(
         TrainMode.segment, "--mode", help="Training mode."
     ),
-    train_fraction: float = typer.Option(
-        0.7, "--train", help="Fraction of frames for training."
+    train_fraction: float | None = typer.Option(
+        None,
+        "--train",
+        help="Fraction of frames for training (default: config.yaml).",
     ),
-    val_fraction: float = typer.Option(
-        0.15,
+    val_fraction: float | None = typer.Option(
+        None,
         "--val",
         help=(
-            "Fraction of frames for validation. The remainder becomes "
-            "the test split."
+            "Fraction of frames for validation; the remainder becomes "
+            "the test split (default: config.yaml)."
         ),
     ),
-    seed: int = typer.Option(
-        88, "--seed", help="Random seed for reproducibility."
+    seed: int | None = typer.Option(
+        None,
+        "--seed",
+        help="Random seed for reproducibility (default: config.yaml).",
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print split sizes without writing files."
@@ -326,20 +330,29 @@ def train(
             "already been run."
         ),
     ),
-    train_fraction: float = typer.Option(
-        0.7,
+    train_fraction: float | None = typer.Option(
+        None,
         "--train",
-        help="Fraction of frames for training (ignored with --no-split).",
+        help=(
+            "Fraction of frames for training (default: config.yaml; "
+            "ignored with --no-split)."
+        ),
     ),
-    val_fraction: float = typer.Option(
-        0.15,
+    val_fraction: float | None = typer.Option(
+        None,
         "--val",
-        help="Fraction of frames for validation (ignored with --no-split).",
+        help=(
+            "Fraction of frames for validation (default: config.yaml; "
+            "ignored with --no-split)."
+        ),
     ),
-    seed: int = typer.Option(
-        88,
+    seed: int | None = typer.Option(
+        None,
         "--seed",
-        help="Random seed for the split (ignored with --no-split).",
+        help=(
+            "Random seed for the split (default: config.yaml; ignored "
+            "with --no-split)."
+        ),
     ),
 ):
     (

--- a/octron/config.py
+++ b/octron/config.py
@@ -97,6 +97,28 @@ def _coerce_optional_dir(value):
     return text or None
 
 
+def _coerce_fraction(value):
+    """Coerce a split fraction to a float strictly inside ``(0, 1)``."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("expected a number") from e
+    if not 0.0 < number < 1.0:
+        raise ValueError("must be between 0 and 1 (exclusive)")
+    return number
+
+
+def _coerce_nonneg_int(value):
+    """Coerce a value to a non-negative integer (e.g. a random seed)."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("expected an integer") from e
+    if number < 0:
+        raise ValueError("must be >= 0")
+    return number
+
+
 # The settings schema.  Add new user settings here; everything else (loading,
 # validation, the CLI, and a settings dialog) picks them up automatically.
 SETTINGS: "tuple[SettingSpec, ...]" = (
@@ -123,6 +145,38 @@ SETTINGS: "tuple[SettingSpec, ...]" = (
             "installs."
         ),
         coerce=_coerce_optional_dir,
+    ),
+    SettingSpec(
+        key="split_train_fraction",
+        default=0.7,
+        kind="float",
+        description=(
+            "Fraction of annotated frames used for the training split "
+            "(train + val must be < 1; the remainder is the test split). "
+            "Used by 'octron split'/'train' when --train is omitted, and "
+            "by the GUI."
+        ),
+        coerce=_coerce_fraction,
+    ),
+    SettingSpec(
+        key="split_val_fraction",
+        default=0.15,
+        kind="float",
+        description=(
+            "Fraction of annotated frames used for the validation split. "
+            "Used when --val is omitted, and by the GUI."
+        ),
+        coerce=_coerce_fraction,
+    ),
+    SettingSpec(
+        key="split_seed",
+        default=88,
+        kind="int",
+        description=(
+            "Random seed for the reproducible train/val/test split. Used "
+            "when --seed is omitted, and by the GUI."
+        ),
+        coerce=_coerce_nonneg_int,
     ),
 )
 
@@ -316,3 +370,28 @@ def get_reid_weights_dir() -> Path:
     d = get_model_cache_dir() / "reid"
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def get_split_fractions() -> "tuple[float, float]":
+    """Return ``(train_fraction, val_fraction)`` for the data split.
+
+    Falls back to the built-in defaults (with a warning) if the stored
+    pair leaves no room for a test split (``train + val >= 1``).
+    """
+    train = get_value("split_train_fraction")
+    val = get_value("split_val_fraction")
+    if train + val >= 1.0:
+        d_train = _SPECS["split_train_fraction"].default
+        d_val = _SPECS["split_val_fraction"].default
+        logger.warning(
+            f"config split fractions train={train} + val={val} >= 1 "
+            f"(no room for a test split); using defaults "
+            f"{d_train}/{d_val}."
+        )
+        return d_train, d_val
+    return train, val
+
+
+def get_split_seed() -> int:
+    """Return the random seed for the train/val/test split."""
+    return get_value("split_seed")

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -84,18 +84,12 @@ def run_split(
         if train_mode == "segment"
         else "Generating bounding boxes..."
     )
-    for (
-        no_entry,
-        total,
-        label,
-        frame_no,
-        total_frames,
-    ) in yolo.prepare_geometry():
-        print(
-            f"  [{no_entry}/{total}] {label}: frame {frame_no}/{total_frames}",
-            end="\r",
-        )
-    print()
+    # tqdm (inside prepare_geometry) renders the per-label progress bar on
+    # stderr. We only drive the generator here; printing our own
+    # carriage-return line to stdout in lockstep with tqdm makes the bar
+    # "staircase" onto new lines (most visibly on Windows).
+    for _ in yolo.prepare_geometry():
+        pass
 
     # --- Step 3: split ---
     print("Splitting data into train/val/test sets...")
@@ -115,20 +109,10 @@ def run_split(
 
     # --- Step 4: export to disk ---
     print("Exporting training data...")
-    for (
-        no_entry,
-        total,
-        label,
-        split,
-        frame_no,
-        total_frames,
-    ) in yolo.create_training_data():
-        print(
-            f"  [{no_entry}/{total}] {label} ({split}): "
-            f"frame {frame_no}/{total_frames}",
-            end="\r",
-        )
-    print()
+    # As above: tqdm owns the export progress bar; we just consume the
+    # generator so a competing stdout writer can't break the bar.
+    for _ in yolo.create_training_data():
+        pass
 
     yolo.write_yolo_config(train_mode=train_mode)
     print("Training data export complete.")

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -18,7 +18,16 @@ _MODELS_YAML = (
 _SPLIT_COLORS = {"train": "green", "val": "cyan", "test": "yellow"}
 _UNANNOTATED_COLOR = "bright_black"
 _BLOCK = "\u2588"  # full block: annotated frames
-_EMPTY = "\u2591"  # light shade: unannotated frames
+_EMPTY = "\u2591"  # light shade: unannotated frames (within an episode)
+_ELLIPSIS = "\u2026"  # … : elided unannotated gap between episodes
+
+# The colored bar shares this many columns across all annotated episodes
+# (each episode gets a share proportional to its frame count). Long gaps
+# between episodes are collapsed to "…" instead of drawn to scale, so
+# sparsely annotated but very long videos stay compact and legible.
+_TIMELINE_BUDGET = 60
+_MIN_EPISODE_WIDTH = 1  # smallest visible episode bar
+_MAX_TIMELINE_EPISODES = 40  # above this, fall back to a plain linear bar
 
 
 def run_split(
@@ -220,12 +229,59 @@ def _timeline_bins(frame_to_split, num_frames, width):
     return [c.most_common(1)[0][0] if c else None for c in buckets]
 
 
-def _render_split_timeline(labels, subfolder_name, width=60):
-    """Print a colored whole-video timeline of the train/val/test split.
+def _segment_episodes(frames, gap):
+    """Group sorted frame indices into episodes, splitting at gaps > ``gap``.
 
-    The bar spans the entire video (frame 0..num_frames); contiguous
-    train/val/test blocks show as colored runs and unannotated regions
-    as a dim shade, so the episode structure of the split is visible.
+    An episode is a run of annotated frames whose internal gaps never
+    exceed ``gap`` frames; larger gaps are elided (``…``) in the bar.
+    """
+    episodes = [[frames[0]]]
+    for frame in frames[1:]:
+        if frame - episodes[-1][-1] > gap:
+            episodes.append([frame])
+        else:
+            episodes[-1].append(frame)
+    return episodes
+
+
+def _episode_bar(frames, frame_to_split, width, click):
+    """Render one episode's frame span as ``width`` colored blocks."""
+    start, end = frames[0], frames[-1]
+    span = max(1, end - start + 1)
+    buckets = [Counter() for _ in range(width)]
+    for frame in frames:
+        col = min(width - 1, int((frame - start) * width / span))
+        buckets[col][frame_to_split[frame]] += 1
+    cells = []
+    for counter in buckets:
+        if counter:
+            split = counter.most_common(1)[0][0]
+            cells.append(click.style(_BLOCK, fg=_SPLIT_COLORS[split]))
+        else:
+            cells.append(click.style(_EMPTY, fg=_UNANNOTATED_COLOR))
+    return "".join(cells)
+
+
+def _linear_bar(frame_to_split, num_frames, width, click):
+    """Render a plain, to-scale whole-video bar (no gap elision)."""
+    bins = _timeline_bins(frame_to_split, num_frames, min(width, num_frames))
+    return "".join(
+        click.style(_BLOCK, fg=_SPLIT_COLORS[b])
+        if b is not None
+        else click.style(_EMPTY, fg=_UNANNOTATED_COLOR)
+        for b in bins
+    )
+
+
+def _render_split_timeline(labels, subfolder_name, width=_TIMELINE_BUDGET):
+    """Print a colored timeline of the train/val/test split.
+
+    Annotated episodes are drawn as train/val/test runs sized in
+    proportion to their frame counts, and long unannotated gaps between
+    episodes are collapsed to ``…``. This keeps the annotated structure
+    legible even for sparsely annotated, very long videos (where a
+    to-scale bar would be almost all empty). If the annotations are too
+    fragmented to compress usefully, fall back to a plain linear bar.
     """
     import click
 
@@ -236,31 +292,46 @@ def _render_split_timeline(labels, subfolder_name, width=60):
     if num_frames <= 0:
         return
 
-    width = min(width, num_frames)
-    bins = _timeline_bins(frame_to_split, num_frames, width)
-    bar = "".join(
-        click.style(_BLOCK, fg=_SPLIT_COLORS[b])
-        if b is not None
-        else click.style(_EMPTY, fg=_UNANNOTATED_COLOR)
-        for b in bins
+    frames = sorted(frame_to_split)
+    # A gap wider than ~3% of the video is elided rather than drawn.
+    gap = max(10, num_frames // 33)
+    episodes = _segment_episodes(frames, gap)
+    dim_ellipsis = click.style(f" {_ELLIPSIS} ", fg=_UNANNOTATED_COLOR)
+
+    if len(episodes) > _MAX_TIMELINE_EPISODES:
+        bar = _linear_bar(frame_to_split, num_frames, width, click)
+    else:
+        total = len(frames)
+        parts = []
+        if frames[0] > gap:
+            parts.append(dim_ellipsis)  # gap before the first episode
+        for i, episode in enumerate(episodes):
+            ep_w = max(_MIN_EPISODE_WIDTH, round(width * len(episode) / total))
+            parts.append(_episode_bar(episode, frame_to_split, ep_w, click))
+            if i < len(episodes) - 1:
+                parts.append(dim_ellipsis)
+        if num_frames - 1 - frames[-1] > gap:
+            parts.append(dim_ellipsis)  # gap after the last episode
+        bar = "".join(parts)
+
+    click.echo(
+        f"\nTimeline: {subfolder_name}  ({num_frames} frames, "
+        f"{len(frames)} annotated, {len(episodes)} episode(s))"
     )
+    click.echo(f"0 {bar} {num_frames}")
     legend = "  ".join(
         (
             click.style(_BLOCK, fg=_SPLIT_COLORS["train"]) + " train",
             click.style(_BLOCK, fg=_SPLIT_COLORS["val"]) + " val",
             click.style(_BLOCK, fg=_SPLIT_COLORS["test"]) + " test",
             click.style(_EMPTY, fg=_UNANNOTATED_COLOR) + " unannotated",
+            f"{_ELLIPSIS} gap",
         )
     )
-    click.echo(
-        f"\nTimeline: {subfolder_name}  "
-        f"({num_frames} frames, {len(frame_to_split)} annotated)"
-    )
-    click.echo(f"0 {bar} {num_frames}")
     click.echo(f"Legend: {legend}")
 
 
-def _print_split_timelines(label_dict, width=60):
+def _print_split_timelines(label_dict, width=_TIMELINE_BUDGET):
     """Print a colored split timeline per subfolder (whole-video view)."""
     for subfolder, labels in label_dict.items():
         _render_split_timeline(labels, Path(subfolder).name, width=width)

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -5,36 +5,18 @@ running model training.  The `octron train` command calls this internally;
 users can also run it standalone via `octron split`.
 """
 
-from collections import Counter
 from pathlib import Path
 
 _MODELS_YAML = (
     Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
 )
 
-# Terminal timeline styling. Click strips these ANSI colors automatically
-# when stdout is not a TTY (e.g. piped to a file), so the bar degrades to a
-# plain-text block/shade fallback without any extra dependency.
-_SPLIT_COLORS = {"train": "green", "val": "cyan", "test": "yellow"}
-_UNANNOTATED_COLOR = "bright_black"
-_BLOCK = "\u2588"  # full block: annotated frames
-_EMPTY = "\u2591"  # light shade: unannotated frames (within an episode)
-_ELLIPSIS = "\u2026"  # … : elided unannotated gap between episodes
-
-# The colored bar shares this many columns across all annotated episodes
-# (each episode gets a share proportional to its frame count). Long gaps
-# between episodes are collapsed to "…" instead of drawn to scale, so
-# sparsely annotated but very long videos stay compact and legible.
-_TIMELINE_BUDGET = 60
-_MIN_EPISODE_WIDTH = 1  # smallest visible episode bar
-_MAX_TIMELINE_EPISODES = 40  # above this, fall back to a plain linear bar
-
 
 def run_split(
     project_path,
-    train_fraction=0.7,
-    val_fraction=0.15,
-    seed=88,
+    train_fraction=None,
+    val_fraction=None,
+    seed=None,
     train_mode="segment",
     dry_run=False,
 ):
@@ -51,13 +33,16 @@ def run_split(
     ----------
     project_path : str or Path
         Path to the OCTRON project directory.
-    train_fraction : float
-        Fraction of frames assigned to the training split (default 0.7).
-    val_fraction : float
-        Fraction of frames assigned to the validation split (default 0.15).
-        The remainder becomes the test split.
-    seed : int
-        Random seed for reproducibility (default 88).
+    train_fraction : float or None
+        Fraction of frames for the training split. ``None`` (the CLI
+        default) reads ``split_train_fraction`` from ``config.yaml``.
+    val_fraction : float or None
+        Fraction of frames for the validation split; the remainder
+        becomes the test split. ``None`` reads ``split_val_fraction``
+        from config.
+    seed : int or None
+        Random seed for reproducibility. ``None`` reads ``split_seed``
+        from config.
     train_mode : str
         ``'segment'`` for instance segmentation, ``'detect'`` for bounding-box
         detection only.
@@ -70,6 +55,21 @@ def run_split(
     train_mode = (
         train_mode.value if hasattr(train_mode, "value") else str(train_mode)
     )
+
+    # Resolve unset split parameters from config.yaml. Precedence: a CLI
+    # flag (non-None) overrides config, which overrides the built-in
+    # default. The GUI reads the same config for its defaults.
+    if train_fraction is None or val_fraction is None or seed is None:
+        from octron import config
+
+        if train_fraction is None or val_fraction is None:
+            cfg_train, cfg_val = config.get_split_fractions()
+            if train_fraction is None:
+                train_fraction = cfg_train
+            if val_fraction is None:
+                val_fraction = cfg_val
+        if seed is None:
+            seed = config.get_split_seed()
 
     # Validate fractions up front using the core guard (also enforced
     # inside prepare_split) so the CLI fails before any model, label, or
@@ -108,9 +108,10 @@ def run_split(
         random_seed=seed,
     )
 
-    # Print summary table + colored whole-video timelines
-    _print_split_summary(yolo.label_dict, seed)
-    _print_split_timelines(yolo.label_dict)
+    # Print summary table + colored whole-video timelines (shared w/ GUI)
+    from octron.yolo_octron.helpers.split_report import render_split_report
+
+    render_split_report(yolo.summarize_split(), seed)
 
     if dry_run:
         print("Dry run — no files written.")
@@ -125,233 +126,3 @@ def run_split(
 
     yolo.write_yolo_config(train_mode=train_mode)
     print("Training data export complete.")
-
-
-def _print_split_summary(label_dict, seed):
-    """Print a per-label, per-split frame count table."""
-    rows = []
-    for subfolder, labels in label_dict.items():
-        for entry, info in labels.items():
-            if entry in ("video", "video_file_path"):
-                continue
-            split = info.get("frames_split", {})
-            rows.append(
-                (
-                    Path(subfolder).name,
-                    info["label"],
-                    len(split.get("train", [])),
-                    len(split.get("val", [])),
-                    len(split.get("test", [])),
-                    len(info["frames"]),
-                )
-            )
-
-    if not rows:
-        return
-
-    col_w = [max(len(str(r[i])) for r in rows) for i in range(6)]
-    col_w = [
-        max(w, h) for w, h in zip(col_w, [8, 5, 5, 3, 4, 5], strict=False)
-    ]
-    header = (
-        f"{'Subfolder':{col_w[0]}}  "
-        f"{'Label':{col_w[1]}}  "
-        f"{'Train':>{col_w[2]}}  "
-        f"{'Val':>{col_w[3]}}  "
-        f"{'Test':>{col_w[4]}}  "
-        f"{'Total':>{col_w[5]}}"
-    )
-    sep = "-" * len(header)
-    print(f"\nSplit summary  (seed={seed})")
-    print(sep)
-    print(header)
-    print(sep)
-    for subfolder, label, tr, va, te, tot in rows:  # codespell:ignore te
-        print(
-            f"{subfolder:{col_w[0]}}  "
-            f"{label:{col_w[1]}}  "
-            f"{tr:>{col_w[2]}}  "
-            f"{va:>{col_w[3]}}  "
-            f"{te:>{col_w[4]}}  "  # codespell:ignore te
-            f"{tot:>{col_w[5]}}"
-        )
-    print(sep)
-    print()
-
-
-def _build_frame_to_split(labels):
-    """Map each annotated frame index to its split for one subfolder.
-
-    Aggregates every label in the subfolder. With empty-label pruning
-    (the default) all labels share the same frames, so the mapping is
-    unambiguous; without it, the last label wins on the rare conflict.
-    """
-    frame_to_split = {}
-    for entry, info in labels.items():
-        if entry in ("video", "video_file_path"):
-            continue
-        split = info.get("frames_split", {})
-        for name in ("train", "val", "test"):
-            for frame in split.get(name, []):
-                frame_to_split[int(frame)] = name
-    return frame_to_split
-
-
-def _num_frames_for(labels, frame_to_split):
-    """Best-effort whole-video length for a subfolder.
-
-    Prefers the mask zarr length (the true video length); falls back to
-    the largest annotated index when masks are unavailable.
-    """
-    for entry, info in labels.items():
-        if entry in ("video", "video_file_path"):
-            continue
-        masks = info.get("masks")
-        if masks:
-            try:
-                return int(masks[0].shape[0])
-            except (AttributeError, IndexError, TypeError):
-                pass
-    return (max(frame_to_split) + 1) if frame_to_split else 0
-
-
-def _annotated_frame_count(labels):
-    """Count all annotated frames in a subfolder (union across labels).
-
-    This is the pre-split total (matching the summary's ``Total``). It can
-    exceed the number of frames assigned to train/val/test because
-    ``train_test_val`` drops ``buffer`` frames at block boundaries; those
-    dropped frames show as gaps in the timeline.
-    """
-    frames = set()
-    for entry, info in labels.items():
-        if entry in ("video", "video_file_path"):
-            continue
-        for frame in info.get("frames", []):
-            frames.add(int(frame))
-    return len(frames)
-
-
-def _timeline_bins(frame_to_split, num_frames, width):
-    """Reduce a frame->split mapping into ``width`` columns.
-
-    Each column reports the dominant split among the frames that fall in
-    it, or ``None`` when no annotated frame lands there (unannotated).
-    """
-    buckets = [Counter() for _ in range(width)]
-    for frame, name in frame_to_split.items():
-        if 0 <= frame < num_frames:
-            col = min(width - 1, int(frame * width / num_frames))
-            buckets[col][name] += 1
-    return [c.most_common(1)[0][0] if c else None for c in buckets]
-
-
-def _segment_episodes(frames, gap):
-    """Group sorted frame indices into episodes, splitting at gaps > ``gap``.
-
-    An episode is a run of annotated frames whose internal gaps never
-    exceed ``gap`` frames; larger gaps are elided (``…``) in the bar.
-    """
-    episodes = [[frames[0]]]
-    for frame in frames[1:]:
-        if frame - episodes[-1][-1] > gap:
-            episodes.append([frame])
-        else:
-            episodes[-1].append(frame)
-    return episodes
-
-
-def _episode_bar(frames, frame_to_split, width, click):
-    """Render one episode's frame span as ``width`` colored blocks."""
-    start, end = frames[0], frames[-1]
-    span = max(1, end - start + 1)
-    buckets = [Counter() for _ in range(width)]
-    for frame in frames:
-        col = min(width - 1, int((frame - start) * width / span))
-        buckets[col][frame_to_split[frame]] += 1
-    cells = []
-    for counter in buckets:
-        if counter:
-            split = counter.most_common(1)[0][0]
-            cells.append(click.style(_BLOCK, fg=_SPLIT_COLORS[split]))
-        else:
-            cells.append(click.style(_EMPTY, fg=_UNANNOTATED_COLOR))
-    return "".join(cells)
-
-
-def _linear_bar(frame_to_split, num_frames, width, click):
-    """Render a plain, to-scale whole-video bar (no gap elision)."""
-    bins = _timeline_bins(frame_to_split, num_frames, min(width, num_frames))
-    return "".join(
-        click.style(_BLOCK, fg=_SPLIT_COLORS[b])
-        if b is not None
-        else click.style(_EMPTY, fg=_UNANNOTATED_COLOR)
-        for b in bins
-    )
-
-
-def _render_split_timeline(labels, subfolder_name, width=_TIMELINE_BUDGET):
-    """Print a colored timeline of the train/val/test split.
-
-    Annotated episodes are drawn as train/val/test runs sized in
-    proportion to their frame counts, and long unannotated gaps between
-    episodes are collapsed to ``…``. This keeps the annotated structure
-    legible even for sparsely annotated, very long videos (where a
-    to-scale bar would be almost all empty). If the annotations are too
-    fragmented to compress usefully, fall back to a plain linear bar.
-    """
-    import click
-
-    frame_to_split = _build_frame_to_split(labels)
-    if not frame_to_split:
-        return
-    num_frames = _num_frames_for(labels, frame_to_split)
-    if num_frames <= 0:
-        return
-
-    frames = sorted(frame_to_split)
-    # A gap wider than ~3% of the video is elided rather than drawn.
-    gap = max(10, num_frames // 33)
-    episodes = _segment_episodes(frames, gap)
-    dim_ellipsis = click.style(f" {_ELLIPSIS} ", fg=_UNANNOTATED_COLOR)
-
-    if len(episodes) > _MAX_TIMELINE_EPISODES:
-        bar = _linear_bar(frame_to_split, num_frames, width, click)
-    else:
-        total = len(frames)
-        parts = []
-        if frames[0] > gap:
-            parts.append(dim_ellipsis)  # gap before the first episode
-        for i, episode in enumerate(episodes):
-            ep_w = max(_MIN_EPISODE_WIDTH, round(width * len(episode) / total))
-            parts.append(_episode_bar(episode, frame_to_split, ep_w, click))
-            if i < len(episodes) - 1:
-                parts.append(dim_ellipsis)
-        if num_frames - 1 - frames[-1] > gap:
-            parts.append(dim_ellipsis)  # gap after the last episode
-        bar = "".join(parts)
-
-    n_assigned = len(frames)
-    n_buffered = max(0, _annotated_frame_count(labels) - n_assigned)
-    click.echo(
-        f"\nTimeline: {subfolder_name}  ({num_frames} frames, "
-        f"{n_assigned} assigned, {n_buffered} buffered, "
-        f"{len(episodes)} episode(s))"
-    )
-    click.echo(f"0 {bar} {num_frames}")
-    legend = "  ".join(
-        (
-            click.style(_BLOCK, fg=_SPLIT_COLORS["train"]) + " train",
-            click.style(_BLOCK, fg=_SPLIT_COLORS["val"]) + " val",
-            click.style(_BLOCK, fg=_SPLIT_COLORS["test"]) + " test",
-            click.style(_EMPTY, fg=_UNANNOTATED_COLOR) + " unannotated",
-            f"{_ELLIPSIS} gap",
-        )
-    )
-    click.echo(f"Legend: {legend}")
-
-
-def _print_split_timelines(label_dict, width=_TIMELINE_BUDGET):
-    """Print a colored split timeline per subfolder (whole-video view)."""
-    for subfolder, labels in label_dict.items():
-        _render_split_timeline(labels, Path(subfolder).name, width=width)

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -5,11 +5,20 @@ running model training.  The `octron train` command calls this internally;
 users can also run it standalone via `octron split`.
 """
 
+from collections import Counter
 from pathlib import Path
 
 _MODELS_YAML = (
     Path(__file__).parent.parent / "yolo_octron" / "yolo_models.yaml"
 )
+
+# Terminal timeline styling. Click strips these ANSI colors automatically
+# when stdout is not a TTY (e.g. piped to a file), so the bar degrades to a
+# plain-text block/shade fallback without any extra dependency.
+_SPLIT_COLORS = {"train": "green", "val": "cyan", "test": "yellow"}
+_UNANNOTATED_COLOR = "bright_black"
+_BLOCK = "\u2588"  # full block: annotated frames
+_EMPTY = "\u2591"  # light shade: unannotated frames
 
 
 def run_split(
@@ -96,8 +105,9 @@ def run_split(
         random_seed=seed,
     )
 
-    # Print summary table
+    # Print summary table + colored whole-video timelines
     _print_split_summary(yolo.label_dict, seed)
+    _print_split_timelines(yolo.label_dict)
 
     if dry_run:
         print("Dry run — no files written.")
@@ -174,3 +184,99 @@ def _print_split_summary(label_dict, seed):
         )
     print(sep)
     print()
+
+
+def _build_frame_to_split(labels):
+    """Map each annotated frame index to its split for one subfolder.
+
+    Aggregates every label in the subfolder. With empty-label pruning
+    (the default) all labels share the same frames, so the mapping is
+    unambiguous; without it, the last label wins on the rare conflict.
+    """
+    frame_to_split = {}
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        split = info.get("frames_split", {})
+        for name in ("train", "val", "test"):
+            for frame in split.get(name, []):
+                frame_to_split[int(frame)] = name
+    return frame_to_split
+
+
+def _num_frames_for(labels, frame_to_split):
+    """Best-effort whole-video length for a subfolder.
+
+    Prefers the mask zarr length (the true video length); falls back to
+    the largest annotated index when masks are unavailable.
+    """
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        masks = info.get("masks")
+        if masks:
+            try:
+                return int(masks[0].shape[0])
+            except (AttributeError, IndexError, TypeError):
+                pass
+    return (max(frame_to_split) + 1) if frame_to_split else 0
+
+
+def _timeline_bins(frame_to_split, num_frames, width):
+    """Reduce a frame->split mapping into ``width`` columns.
+
+    Each column reports the dominant split among the frames that fall in
+    it, or ``None`` when no annotated frame lands there (unannotated).
+    """
+    buckets = [Counter() for _ in range(width)]
+    for frame, name in frame_to_split.items():
+        if 0 <= frame < num_frames:
+            col = min(width - 1, int(frame * width / num_frames))
+            buckets[col][name] += 1
+    return [c.most_common(1)[0][0] if c else None for c in buckets]
+
+
+def _render_split_timeline(labels, subfolder_name, width=60):
+    """Print a colored whole-video timeline of the train/val/test split.
+
+    The bar spans the entire video (frame 0..num_frames); contiguous
+    train/val/test blocks show as colored runs and unannotated regions
+    as a dim shade, so the episode structure of the split is visible.
+    """
+    import click
+
+    frame_to_split = _build_frame_to_split(labels)
+    if not frame_to_split:
+        return
+    num_frames = _num_frames_for(labels, frame_to_split)
+    if num_frames <= 0:
+        return
+
+    width = min(width, num_frames)
+    bins = _timeline_bins(frame_to_split, num_frames, width)
+    bar = "".join(
+        click.style(_BLOCK, fg=_SPLIT_COLORS[b])
+        if b is not None
+        else click.style(_EMPTY, fg=_UNANNOTATED_COLOR)
+        for b in bins
+    )
+    legend = "  ".join(
+        (
+            click.style(_BLOCK, fg=_SPLIT_COLORS["train"]) + " train",
+            click.style(_BLOCK, fg=_SPLIT_COLORS["val"]) + " val",
+            click.style(_BLOCK, fg=_SPLIT_COLORS["test"]) + " test",
+            click.style(_EMPTY, fg=_UNANNOTATED_COLOR) + " unannotated",
+        )
+    )
+    click.echo(
+        f"\nTimeline: {subfolder_name}  "
+        f"({num_frames} frames, {len(frame_to_split)} annotated)"
+    )
+    click.echo(f"0 {bar} {num_frames}")
+    click.echo(f"Legend: {legend}")
+
+
+def _print_split_timelines(label_dict, width=60):
+    """Print a colored split timeline per subfolder (whole-video view)."""
+    for subfolder, labels in label_dict.items():
+        _render_split_timeline(labels, Path(subfolder).name, width=width)

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -215,6 +215,23 @@ def _num_frames_for(labels, frame_to_split):
     return (max(frame_to_split) + 1) if frame_to_split else 0
 
 
+def _annotated_frame_count(labels):
+    """Count all annotated frames in a subfolder (union across labels).
+
+    This is the pre-split total (matching the summary's ``Total``). It can
+    exceed the number of frames assigned to train/val/test because
+    ``train_test_val`` drops ``buffer`` frames at block boundaries; those
+    dropped frames show as gaps in the timeline.
+    """
+    frames = set()
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        for frame in info.get("frames", []):
+            frames.add(int(frame))
+    return len(frames)
+
+
 def _timeline_bins(frame_to_split, num_frames, width):
     """Reduce a frame->split mapping into ``width`` columns.
 
@@ -314,9 +331,12 @@ def _render_split_timeline(labels, subfolder_name, width=_TIMELINE_BUDGET):
             parts.append(dim_ellipsis)  # gap after the last episode
         bar = "".join(parts)
 
+    n_assigned = len(frames)
+    n_buffered = max(0, _annotated_frame_count(labels) - n_assigned)
     click.echo(
         f"\nTimeline: {subfolder_name}  ({num_frames} frames, "
-        f"{len(frames)} annotated, {len(episodes)} episode(s))"
+        f"{n_assigned} assigned, {n_buffered} buffered, "
+        f"{len(episodes)} episode(s))"
     )
     click.echo(f"0 {bar} {num_frames}")
     legend = "  ".join(

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -23,9 +23,9 @@ def run_training(
     overwrite=False,
     resume=False,
     skip_split=False,
-    train_fraction=0.7,
-    val_fraction=0.15,
-    seed=88,
+    train_fraction=None,
+    val_fraction=None,
+    seed=None,
 ):
     """Run the OCTRON/YOLO training pipeline.
 
@@ -58,12 +58,15 @@ def run_training(
     skip_split : bool
         Skip data preparation. Use when ``octron split`` has already been run
         and the training data is up to date.
-    train_fraction : float
-        Fraction of frames for training (ignored when ``skip_split=True``).
-    val_fraction : float
-        Fraction of frames for validation (ignored when ``skip_split=True``).
-    seed : int
-        Random seed for the split (ignored when ``skip_split=True``).
+    train_fraction : float or None
+        Fraction of frames for training. ``None`` reads ``config.yaml``
+        (ignored when ``skip_split=True``).
+    val_fraction : float or None
+        Fraction of frames for validation. ``None`` reads ``config.yaml``
+        (ignored when ``skip_split=True``).
+    seed : int or None
+        Random seed for the split. ``None`` reads ``config.yaml``
+        (ignored when ``skip_split=True``).
 
     """
     from octron.test_gpu import auto_device

--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -525,7 +525,7 @@ class YoloHandler(QObject):
         # training data export worker right after ...
         if self.bbox_or_polygon_generated and not self.training_data_generated:
             # split train/val/test then kick off data export
-            self.yolo.prepare_split()
+            self._split_and_report()
             self._training_data_export()
         else:
             pass
@@ -615,10 +615,32 @@ class YoloHandler(QObject):
             self.bbox_or_polygon_generated = True
 
         if self.bbox_or_polygon_generated and not self.training_data_generated:
-            self.yolo.prepare_split()
+            self._split_and_report()
             self._training_data_export()
         else:
             pass
+
+    def _split_and_report(self):
+        """Split train/val/test from config and print the shared report.
+
+        Reads the split fractions/seed from ``config.yaml`` (the same
+        source the CLI defaults to) and prints the shared summary table +
+        colored timeline to the terminal that launched napari, so the GUI
+        and CLI show an identical split report.
+        """
+        from octron import config
+        from octron.yolo_octron.helpers.split_report import (
+            render_split_report,
+        )
+
+        train_frac, val_frac = config.get_split_fractions()
+        seed = config.get_split_seed()
+        self.yolo.prepare_split(
+            training_fraction=train_frac,
+            validation_fraction=val_frac,
+            random_seed=seed,
+        )
+        render_split_report(self.yolo.summarize_split(), seed)
 
     def _training_data_export(self):
         """Manage the training_data_worker() thread worker."""

--- a/octron/yolo_octron/helpers/split_report.py
+++ b/octron/yolo_octron/helpers/split_report.py
@@ -1,0 +1,316 @@
+"""Shared reporting for the train/val/test split.
+
+This module is the single source of truth for the ``octron split`` summary
+table and the colored, episode-aware timeline, so the CLI (``run_split``)
+and the GUI both render an identical report. It is deliberately split into
+two layers:
+
+- ``build_split_report(label_dict)`` computes pure, click-free structured
+  data (per-subfolder counts and timeline column structure). This is what
+  :meth:`YOLO_octron.summarize_split` returns, so callers can inspect the
+  split programmatically or feed a widget.
+- ``render_split_report(report, seed)`` prints that data to the console:
+  the count table via ``print`` and the colored timeline via ``click``
+  (which strips ANSI automatically when stdout is not a TTY).
+"""
+
+from collections import Counter
+from pathlib import Path
+
+# Terminal timeline styling. Click strips these ANSI colors automatically
+# when stdout is not a TTY (e.g. piped to a file), so the bar degrades to a
+# plain-text block/shade fallback without any extra dependency.
+_SPLIT_COLORS = {"train": "green", "val": "cyan", "test": "yellow"}
+_UNANNOTATED_COLOR = "bright_black"
+_BLOCK = "\u2588"  # full block: annotated frames
+_EMPTY = "\u2591"  # light shade: unannotated frames (within an episode)
+_ELLIPSIS = "\u2026"  # … : elided unannotated gap between episodes
+
+# The colored bar shares this many columns across all annotated episodes
+# (each episode gets a share proportional to its frame count). Long gaps
+# between episodes are collapsed to "…" instead of drawn to scale, so
+# sparsely annotated but very long videos stay compact and legible.
+_TIMELINE_BUDGET = 60
+_MIN_EPISODE_WIDTH = 1  # smallest visible episode bar
+_MAX_TIMELINE_EPISODES = 40  # above this, fall back to a plain linear bar
+
+
+# ---------------------------------------------------------------------------
+# Pure data helpers (no click / no printing)
+# ---------------------------------------------------------------------------
+
+
+def _build_frame_to_split(labels):
+    """Map each annotated frame index to its split for one subfolder.
+
+    Aggregates every label in the subfolder. With empty-label pruning
+    (the default) all labels share the same frames, so the mapping is
+    unambiguous; without it, the last label wins on the rare conflict.
+    """
+    frame_to_split = {}
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        split = info.get("frames_split", {})
+        for name in ("train", "val", "test"):
+            for frame in split.get(name, []):
+                frame_to_split[int(frame)] = name
+    return frame_to_split
+
+
+def _num_frames_for(labels, frame_to_split):
+    """Best-effort whole-video length for a subfolder.
+
+    Prefers the mask zarr length (the true video length); falls back to
+    the largest annotated index when masks are unavailable.
+    """
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        masks = info.get("masks")
+        if masks:
+            try:
+                return int(masks[0].shape[0])
+            except (AttributeError, IndexError, TypeError):
+                pass
+    return (max(frame_to_split) + 1) if frame_to_split else 0
+
+
+def _annotated_frame_count(labels):
+    """Count all annotated frames in a subfolder (union across labels).
+
+    This is the pre-split total (matching the summary's ``Total``). It can
+    exceed the number of frames assigned to train/val/test because
+    ``train_test_val`` drops ``buffer`` frames at block boundaries; those
+    dropped frames show as gaps in the timeline.
+    """
+    frames = set()
+    for entry, info in labels.items():
+        if entry in ("video", "video_file_path"):
+            continue
+        for frame in info.get("frames", []):
+            frames.add(int(frame))
+    return len(frames)
+
+
+def _timeline_bins(frame_to_split, num_frames, width):
+    """Reduce a frame->split mapping into ``width`` columns.
+
+    Each column reports the dominant split among the frames that fall in
+    it, or ``None`` when no annotated frame lands there (unannotated).
+    """
+    buckets = [Counter() for _ in range(width)]
+    for frame, name in frame_to_split.items():
+        if 0 <= frame < num_frames:
+            col = min(width - 1, int(frame * width / num_frames))
+            buckets[col][name] += 1
+    return [c.most_common(1)[0][0] if c else None for c in buckets]
+
+
+def _segment_episodes(frames, gap):
+    """Group sorted frame indices into episodes, splitting at gaps > ``gap``.
+
+    An episode is a run of annotated frames whose internal gaps never
+    exceed ``gap`` frames; larger gaps are elided (``…``) in the bar.
+    """
+    episodes = [[frames[0]]]
+    for frame in frames[1:]:
+        if frame - episodes[-1][-1] > gap:
+            episodes.append([frame])
+        else:
+            episodes[-1].append(frame)
+    return episodes
+
+
+def _episode_cols(frames, frame_to_split, width):
+    """Reduce one episode's frame span into ``width`` dominant-split columns.
+
+    Returns a list of split names (or ``None`` for a column with no frames);
+    the renderer maps these to colored blocks.
+    """
+    start, end = frames[0], frames[-1]
+    span = max(1, end - start + 1)
+    buckets = [Counter() for _ in range(width)]
+    for frame in frames:
+        col = min(width - 1, int((frame - start) * width / span))
+        buckets[col][frame_to_split[frame]] += 1
+    return [c.most_common(1)[0][0] if c else None for c in buckets]
+
+
+def _build_timeline(labels):
+    """Return timeline data for one subfolder, or ``None`` if unsplit.
+
+    ``segments`` is an ordered list describing the bar: ``("gap",)`` for an
+    elided unannotated stretch and ``("blocks", cols)`` for a run of
+    dominant-split columns (``cols`` entries are ``"train"``/``"val"``/
+    ``"test"``/``None``). Annotated episodes are sized proportional to
+    their frame count over a shared column budget; long gaps between
+    episodes collapse to ``("gap",)``. Falls back to a single to-scale
+    ``("blocks", ...)`` segment when the annotations are too fragmented.
+    """
+    frame_to_split = _build_frame_to_split(labels)
+    if not frame_to_split:
+        return None
+    num_frames = _num_frames_for(labels, frame_to_split)
+    if num_frames <= 0:
+        return None
+
+    frames = sorted(frame_to_split)
+    gap = max(10, num_frames // 33)
+    episodes = _segment_episodes(frames, gap)
+    segments = []
+    if len(episodes) > _MAX_TIMELINE_EPISODES:
+        width = min(_TIMELINE_BUDGET, num_frames)
+        segments.append(
+            ("blocks", _timeline_bins(frame_to_split, num_frames, width))
+        )
+    else:
+        total = len(frames)
+        if frames[0] > gap:
+            segments.append(("gap",))
+        for i, episode in enumerate(episodes):
+            ep_w = max(
+                _MIN_EPISODE_WIDTH,
+                round(_TIMELINE_BUDGET * len(episode) / total),
+            )
+            segments.append(
+                ("blocks", _episode_cols(episode, frame_to_split, ep_w))
+            )
+            if i < len(episodes) - 1:
+                segments.append(("gap",))
+        if num_frames - 1 - frames[-1] > gap:
+            segments.append(("gap",))
+
+    return {
+        "num_frames": num_frames,
+        "assigned": len(frames),
+        "buffered": max(0, _annotated_frame_count(labels) - len(frames)),
+        "n_episodes": len(episodes),
+        "segments": segments,
+    }
+
+
+def build_split_report(label_dict):
+    """Compute the structured split report (counts + timeline) per subfolder.
+
+    Pure and click-free; this is what :meth:`YOLO_octron.summarize_split`
+    returns and what :func:`render_split_report` consumes.
+    """
+    report = []
+    for subfolder, labels in label_dict.items():
+        rows = []
+        for entry, info in labels.items():
+            if entry in ("video", "video_file_path"):
+                continue
+            split = info.get("frames_split", {})
+            rows.append(
+                (
+                    info["label"],
+                    len(split.get("train", [])),
+                    len(split.get("val", [])),
+                    len(split.get("test", [])),
+                    len(info.get("frames", [])),
+                )
+            )
+        report.append(
+            {
+                "name": Path(subfolder).name,
+                "rows": rows,
+                "timeline": _build_timeline(labels),
+            }
+        )
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Rendering (console: print for the table, click for the colored timeline)
+# ---------------------------------------------------------------------------
+
+
+def _render_summary_table(report, seed):
+    """Print a per-label, per-split frame count table."""
+    rows = []
+    for sub in report:
+        for label, tr, va, test_n, tot in sub["rows"]:
+            rows.append((sub["name"], label, tr, va, test_n, tot))
+    if not rows:
+        return
+
+    col_w = [max(len(str(r[i])) for r in rows) for i in range(6)]
+    col_w = [
+        max(w, h) for w, h in zip(col_w, [8, 5, 5, 3, 4, 5], strict=False)
+    ]
+    header = (
+        f"{'Subfolder':{col_w[0]}}  "
+        f"{'Label':{col_w[1]}}  "
+        f"{'Train':>{col_w[2]}}  "
+        f"{'Val':>{col_w[3]}}  "
+        f"{'Test':>{col_w[4]}}  "
+        f"{'Total':>{col_w[5]}}"
+    )
+    sep = "-" * len(header)
+    print(f"\nSplit summary  (seed={seed})")
+    print(sep)
+    print(header)
+    print(sep)
+    for subfolder, label, tr, va, test_n, tot in rows:
+        print(
+            f"{subfolder:{col_w[0]}}  "
+            f"{label:{col_w[1]}}  "
+            f"{tr:>{col_w[2]}}  "
+            f"{va:>{col_w[3]}}  "
+            f"{test_n:>{col_w[4]}}  "
+            f"{tot:>{col_w[5]}}"
+        )
+    print(sep)
+    print()
+
+
+def _render_timeline(sub, click):
+    """Print one subfolder's colored whole-video timeline."""
+    tl = sub["timeline"]
+    if tl is None:
+        return
+    dim_ellipsis = click.style(f" {_ELLIPSIS} ", fg=_UNANNOTATED_COLOR)
+    parts = []
+    for segment in tl["segments"]:
+        if segment[0] == "gap":
+            parts.append(dim_ellipsis)
+            continue
+        for split in segment[1]:
+            if split is not None:
+                parts.append(click.style(_BLOCK, fg=_SPLIT_COLORS[split]))
+            else:
+                parts.append(click.style(_EMPTY, fg=_UNANNOTATED_COLOR))
+    bar = "".join(parts)
+    click.echo(
+        f"\nTimeline: {sub['name']}  ({tl['num_frames']} frames, "
+        f"{tl['assigned']} assigned, {tl['buffered']} buffered, "
+        f"{tl['n_episodes']} episode(s))"
+    )
+    click.echo(f"0 {bar} {tl['num_frames']}")
+    legend = "  ".join(
+        (
+            click.style(_BLOCK, fg=_SPLIT_COLORS["train"]) + " train",
+            click.style(_BLOCK, fg=_SPLIT_COLORS["val"]) + " val",
+            click.style(_BLOCK, fg=_SPLIT_COLORS["test"]) + " test",
+            click.style(_EMPTY, fg=_UNANNOTATED_COLOR) + " unannotated",
+            f"{_ELLIPSIS} gap",
+        )
+    )
+    click.echo(f"Legend: {legend}")
+
+
+def render_split_report(report, seed):
+    """Print the split summary table and colored timelines to the console.
+
+    Shared by the CLI (``run_split``) and the GUI so both surfaces show an
+    identical report. ``report`` is the output of :func:`build_split_report`
+    (or :meth:`YOLO_octron.summarize_split`); ``seed`` is shown in the table
+    header only.
+    """
+    import click
+
+    _render_summary_table(report, seed)
+    for sub in report:
+        _render_timeline(sub, click)

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -715,29 +715,67 @@ def _block_split(
     return out
 
 
-def _split_episodes(
+def _cut_into_blocks(frames, block_size):
+    """Cut one contiguous frame run into ~``block_size`` blocks."""
+    n_blocks = max(1, round(len(frames) / max(1, block_size)))
+    return np.array_split(frames, n_blocks)
+
+
+def _stratified_labels(n_blocks, n_val, n_test, rng):
+    """Label blocks so val/test are spread across the timeline.
+
+    ``val`` and ``test`` each take one block per contiguous stratum
+    (evenly spaced over the block sequence), picked within the stratum by
+    ``rng`` -- so the split is reproducible yet seed-sensitive, and both
+    splits sample the whole timeline instead of clustering in one region.
+    Every other block is ``train``.
+    """
+
+    def pick_spread(pool, k):
+        return [int(rng.choice(s)) for s in np.array_split(pool, k)]
+
+    labels = np.array(["train"] * n_blocks, dtype="<U5")
+    all_idx = np.arange(n_blocks)
+    labels[pick_spread(all_idx, n_val)] = "val"
+    remaining = all_idx[labels == "train"]
+    labels[pick_spread(remaining, n_test)] = "test"
+    return labels.tolist()
+
+
+def _global_block_split(
     episodes, training_fraction, validation_fraction, rng, block_size, buffer
 ):
-    """Block-split each episode independently; tiny episodes go to train.
+    """Split episodes against a single global block budget.
 
-    Episodes with fewer than 3 frames cannot yield one block per split, so
-    they are added wholesale to train (too short to validate on anyway).
+    Each episode is cut into ~``block_size`` contiguous blocks and all
+    blocks across episodes share one train/val/test budget, so the
+    realized proportions track the requested fractions regardless of how
+    many (or how small) the episodes are. val/test blocks are spread
+    across the timeline and the buffer is applied only within an episode
+    (never across the large gap between episodes). Returns ``None`` when
+    there are fewer than 3 blocks total so the caller can fall back to a
+    single-group split.
     """
+    episode_blocks = [_cut_into_blocks(ep, block_size) for ep in episodes]
+    n_blocks = sum(len(b) for b in episode_blocks)
+    if n_blocks < 3:
+        return None
+
+    test_fraction = 1.0 - training_fraction - validation_fraction
+    _, n_val, n_test = _allocate_split_blocks(
+        n_blocks, validation_fraction, test_fraction
+    )
+    labels = _stratified_labels(n_blocks, n_val, n_test, rng)
+
     buckets = {"train": [], "val": [], "test": []}
-    for episode in episodes:
-        if len(episode) >= 3:
-            part = _block_split(
-                episode,
-                training_fraction,
-                validation_fraction,
-                rng,
-                block_size,
-                buffer,
-            )
-            for name in buckets:
-                buckets[name].append(part[name])
-        else:
-            buckets["train"].append(episode)
+    pos = 0
+    for blocks in episode_blocks:
+        ep_labels = labels[pos : pos + len(blocks)]
+        pos += len(blocks)
+        eff_buffer = buffer if min(len(b) for b in blocks) > buffer else 0
+        ep_buckets = _blocks_to_splits(blocks, ep_labels, eff_buffer)
+        for name in buckets:
+            buckets[name].extend(ep_buckets[name])
     return buckets
 
 
@@ -762,13 +800,17 @@ def train_test_val(
     neighbour on opposite sides of train/val (optimistic metrics) and lets
     a denser episode dominate val/test.
 
-    This splits *within each episode by
-    contiguous blocks* instead: frames are first segmented into episodes at
-    large temporal gaps, then each episode is cut into small contiguous
-    blocks whose whole blocks are assigned to a split. So every episode is
-    represented in every split (balanced), temporally adjacent frames stay
-    on the same side, and a buffer of frames is dropped at block
-    boundaries to add a gap.
+    This splits by *contiguous blocks pooled across episodes* instead:
+    frames are first segmented into episodes at large temporal gaps, each
+    episode is cut into small contiguous blocks, and all blocks across
+    episodes share one train/val/test budget so the realized proportions
+    match the requested fractions no matter how many (or how small) the
+    episodes are. The val/test blocks are spread across the timeline
+    (stratified) so they stay representative, temporally adjacent frames
+    stay on the same side, and a buffer of frames is dropped at block
+    boundaries within an episode to add a gap. Small episodes may fall
+    entirely in one split (usually train); they are not force-split three
+    ways.
 
     Parameters
     ----------
@@ -822,7 +864,7 @@ def train_test_val(
     )
 
     rng = np.random.default_rng(random_seed)
-    buckets = _split_episodes(
+    buckets = _global_block_split(
         episodes,
         training_fraction,
         validation_fraction,
@@ -831,11 +873,18 @@ def train_test_val(
         buffer,
     )
     dtype = sorted_frames.dtype
-    split_dict = {k: _concat_blocks(v, dtype) for k, v in buckets.items()}
+    if buckets is not None:
+        split_dict = {k: _concat_blocks(v, dtype) for k, v in buckets.items()}
+    else:
+        split_dict = None
 
-    # Fallback: if per-episode splitting left val or test empty (e.g. every
-    # episode was too small), split the whole set as a single block group.
-    if len(split_dict["val"]) == 0 or len(split_dict["test"]) == 0:
+    # Fallback: too few blocks to spread three ways, or the buffer emptied
+    # val/test -- split the whole set as one contiguous block group.
+    if (
+        split_dict is None
+        or len(split_dict["val"]) == 0
+        or len(split_dict["test"]) == 0
+    ):
         split_dict = _block_split(
             sorted_frames,
             training_fraction,

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -598,33 +598,210 @@ def draw_polygons(
             counter += 1
 
 
+def _allocate_split_blocks(n_blocks, validation_fraction, test_fraction):
+    """Return ``(n_train, n_val, n_test)`` block counts, each at least 1.
+
+    Fractions are applied at block granularity; val and test each keep at
+    least one block and are trimmed so train keeps at least one too.
+    """
+    n_val = max(1, round(validation_fraction * n_blocks))
+    n_test = max(1, round(test_fraction * n_blocks))
+    while n_val + n_test >= n_blocks:
+        if n_test >= n_val and n_test > 1:
+            n_test -= 1
+        elif n_val > 1:
+            n_val -= 1
+        else:
+            break
+    return n_blocks - n_val - n_test, n_val, n_test
+
+
+def _blocks_to_splits(blocks, split_labels, buffer):
+    """Group contiguous blocks into per-split frame-index lists.
+
+    ``split_labels[b]`` is the split name for block ``b``. When ``buffer``
+    is > 0 the leading ``buffer`` frames of a block are dropped whenever
+    the previous block belongs to a different split, creating a temporal
+    gap so no adjacent near-duplicate pair straddles the split.
+    """
+    buckets = {"train": [], "val": [], "test": []}
+    for b, block in enumerate(blocks):
+        blk = block
+        if buffer and b > 0 and split_labels[b] != split_labels[b - 1]:
+            blk = blk[buffer:]
+        if len(blk):
+            buckets[split_labels[b]].append(blk)
+    return buckets
+
+
+def _concat_blocks(parts, dtype):
+    """Concatenate frame-index arrays; empty input -> empty array."""
+    if parts:
+        return np.concatenate(parts)
+    return np.array([], dtype=dtype)
+
+
+def _assert_valid_split(split_dict, sorted_frames):
+    """Assert splits are non-empty, disjoint, and a subset of the input."""
+    seen: set[int] = set()
+    for name, frames in split_dict.items():
+        assert len(frames) > 0, f"Empty {name} split"
+        fset = {int(f) for f in frames}
+        assert not (fset & seen), "Splits overlap"
+        seen |= fset
+    assert seen.issubset({int(f) for f in sorted_frames}), (
+        "Split contains frames not present in the input"
+    )
+
+
+def _segment_episodes(sorted_frames, gap_threshold, gap_factor, block_size):
+    """Split sorted frames into episodes at large temporal gaps.
+
+    An episode boundary is a jump between consecutive annotated frames that
+    is much larger than the typical spacing, so annotation bursts recorded
+    in different parts of a video become separate episodes. When
+    ``gap_threshold`` is None it is derived from the data as
+    ``max(block_size, gap_factor * p90(diffs))`` -- a high percentile so a
+    sparser episode's normal skip spacing is not mistaken for a boundary.
+    """
+    if len(sorted_frames) < 2:
+        return [sorted_frames]
+    diffs = np.diff(sorted_frames)
+    if gap_threshold is None:
+        typical = np.percentile(diffs, 90)
+        threshold = max(block_size, round(gap_factor * typical))
+    else:
+        threshold = gap_threshold
+    boundaries = np.where(diffs > threshold)[0]
+    if len(boundaries) == 0:
+        return [sorted_frames]
+    return np.split(sorted_frames, boundaries + 1)
+
+
+def _block_split(
+    frames, training_fraction, validation_fraction, rng, block_size, buffer
+):
+    """Contiguous-block split of one already-sorted frame run.
+
+    Cuts ``frames`` into at least 3 contiguous blocks (~``block_size``
+    each), assigns whole blocks to train/val/test with ``rng`` (so val and
+    test are spread across the run), and drops ``buffer`` frames at
+    boundaries between differently-assigned blocks. ``frames`` must have at
+    least 3 entries.
+    """
+    n = len(frames)
+    n_blocks = max(3, min(n, round(n / max(1, block_size))))
+    blocks = np.array_split(frames, n_blocks)
+    n_blocks = len(blocks)
+    eff_buffer = buffer if min(len(b) for b in blocks) > buffer else 0
+
+    test_fraction = 1.0 - training_fraction - validation_fraction
+    _, n_val, n_test = _allocate_split_blocks(
+        n_blocks, validation_fraction, test_fraction
+    )
+    perm = rng.permutation(n_blocks)
+    labels = np.array(["train"] * n_blocks, dtype="<U5")
+    labels[perm[:n_val]] = "val"
+    labels[perm[n_val : n_val + n_test]] = "test"
+    labels = labels.tolist()
+
+    buckets = _blocks_to_splits(blocks, labels, eff_buffer)
+    out = {k: _concat_blocks(v, frames.dtype) for k, v in buckets.items()}
+    # A split empties only if its single short block was fully consumed by
+    # the buffer; retry without the buffer (always non-empty).
+    if eff_buffer and any(len(v) == 0 for v in out.values()):
+        buckets = _blocks_to_splits(blocks, labels, 0)
+        out = {k: _concat_blocks(v, frames.dtype) for k, v in buckets.items()}
+    return out
+
+
+def _split_episodes(
+    episodes, training_fraction, validation_fraction, rng, block_size, buffer
+):
+    """Block-split each episode independently; tiny episodes go to train.
+
+    Episodes with fewer than 3 frames cannot yield one block per split, so
+    they are added wholesale to train (too short to validate on anyway).
+    """
+    buckets = {"train": [], "val": [], "test": []}
+    for episode in episodes:
+        if len(episode) >= 3:
+            part = _block_split(
+                episode,
+                training_fraction,
+                validation_fraction,
+                rng,
+                block_size,
+                buffer,
+            )
+            for name in buckets:
+                buckets[name].append(part[name])
+        else:
+            buckets["train"].append(episode)
+    return buckets
+
+
 def train_test_val(
     frame_indices,
     training_fraction=0.8,
     validation_fraction=0.1,
     random_seed=88,
+    block_size=20,
+    buffer=1,
+    gap_threshold=None,
+    gap_factor=5.0,
     verbose=False,
 ):
-    """Perform a train-test-validation split on frame indices.
+    """Split frame indices into train/val/test by episode, then block.
+
+    SAM-assisted annotation (forward propagation)
+    lets users label many frames quickly, so the annotated set
+    is dominated by temporally adjacent, correlated frames -- often
+    across several annotation bursts ("episodes") in different parts of one
+    video. A fully random per-frame split places a frame and its close
+    neighbour on opposite sides of train/val (optimistic metrics) and lets
+    a denser episode dominate val/test.
+
+    This splits *within each episode by
+    contiguous blocks* instead: frames are first segmented into episodes at
+    large temporal gaps, then each episode is cut into small contiguous
+    blocks whose whole blocks are assigned to a split. So every episode is
+    represented in every split (balanced), temporally adjacent frames stay
+    on the same side, and a buffer of frames is dropped at block
+    boundaries to add a gap.
 
     Parameters
     ----------
     frame_indices : np.array
-        Array of frame indices
+        Frame indices (need not be contiguous; sorted internally).
     training_fraction : float
-        Fraction of training data
+        Approximate fraction of blocks for training.
     validation_fraction : float
-        Fraction of validation data
+        Approximate fraction of blocks for validation; test is the
+        remainder.
     random_seed : int
-        Random seed for reproducibility
+        Seed for reproducible (timeline-spread) block assignment.
+    block_size : int
+        Target frames per contiguous block. Adapted down for small
+        episodes so at least 3 blocks (one per split) always exist.
+    buffer : int
+        Frames dropped at each boundary between differently-assigned
+        blocks. Disabled automatically when blocks are too small to spare
+        a frame.
+    gap_threshold : int or None
+        Frame gap above which a new episode begins. None derives it from
+        the data (see :func:`_segment_episodes`).
+    gap_factor : float
+        Multiplier used when deriving the automatic ``gap_threshold``.
     verbose : bool
-        Whether to print sizes of the splits
+        Whether to log split sizes.
 
     Returns
     -------
     split_dict : dict : Dictionary containing the splits
         keys: 'train', 'val', 'test'
-        values: np.array : Frame indices for each split
+        values: np.array : sorted frame indices for each split. Buffered
+        boundary frames are intentionally omitted from all splits.
 
     """
     assert training_fraction + validation_fraction < 1, (
@@ -633,55 +810,46 @@ def train_test_val(
     assert training_fraction > validation_fraction, (
         "Training fraction should be greater than validation fraction"
     )
-    assert len(frame_indices) >= 3, (
-        f"Need at least 3 frames to split into train/val/test, "
-        f"got {len(frame_indices)}"
+    frame_indices = np.asarray(frame_indices)
+    n = len(frame_indices)
+    assert n >= 3, (
+        f"Need at least 3 frames to split into train/val/test, got {n}"
     )
 
-    # Shuffle the indices
-    np.random.seed(random_seed)
-    shuffled_indices = np.random.permutation(len(frame_indices))
+    sorted_frames = np.sort(frame_indices)
+    episodes = _segment_episodes(
+        sorted_frames, gap_threshold, gap_factor, block_size
+    )
 
-    # Calculate split points, ensuring each split gets at least 1 frame
-    n = len(frame_indices)
-    train_size = max(1, int(training_fraction * n))
-    val_size = max(1, int(validation_fraction * n))
-    # Ensure test (remainder) also gets at least 1 frame
-    while train_size + val_size >= n:
-        train_size -= 1
+    rng = np.random.default_rng(random_seed)
+    buckets = _split_episodes(
+        episodes,
+        training_fraction,
+        validation_fraction,
+        rng,
+        block_size,
+        buffer,
+    )
+    dtype = sorted_frames.dtype
+    split_dict = {k: _concat_blocks(v, dtype) for k, v in buckets.items()}
 
-    # Split the shuffled indices
-    train_indices = shuffled_indices[:train_size]
-    val_indices = shuffled_indices[train_size : train_size + val_size]
-    test_indices = shuffled_indices[train_size + val_size :]
-
-    # Get the actual frame numbers for each split
-    train_frames = frame_indices[train_indices]
-    val_frames = frame_indices[val_indices]
-    test_frames = frame_indices[test_indices]
+    # Fallback: if per-episode splitting left val or test empty (e.g. every
+    # episode was too small), split the whole set as a single block group.
+    if len(split_dict["val"]) == 0 or len(split_dict["test"]) == 0:
+        split_dict = _block_split(
+            sorted_frames,
+            training_fraction,
+            validation_fraction,
+            np.random.default_rng(random_seed),
+            block_size,
+            buffer,
+        )
 
     if verbose:
-        logger.info(f"Total frames: {len(frame_indices)}")
-        logger.info(f"Training set: {len(train_frames)} frames")
-        logger.info(f"Validation set: {len(val_frames)} frames")
-        logger.info(f"Test set: {len(test_frames)} frames")
+        logger.info(f"Total frames: {n} in {len(episodes)} episode(s)")
+        logger.info(f"Training set: {len(split_dict['train'])} frames")
+        logger.info(f"Validation set: {len(split_dict['val'])} frames")
+        logger.info(f"Test set: {len(split_dict['test'])} frames")
 
-    split_dict = {
-        "train": train_frames,
-        "val": val_frames,
-        "test": test_frames,
-    }
-
-    # Sanity check
-    collected_frames = []
-    for frames in split_dict.values():
-        assert len(frames) > 0, "Empty split found"
-        collected_frames.extend(frames)
-    assert len(collected_frames) == len(frame_indices), (
-        "Not all frames were collected in the splits"
-    )
-    assert set(collected_frames) == set(frame_indices), (
-        "Some frames are missing in the splits"
-    )
-
+    _assert_valid_split(split_dict, sorted_frames)
     return split_dict

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -722,13 +722,16 @@ def _cut_into_blocks(frames, block_size):
 
 
 def _stratified_labels(n_blocks, n_val, n_test, rng):
-    """Label blocks so val/test are spread across the timeline.
+    """Label blocks so val and test are spread across the timeline.
 
-    ``val`` and ``test`` each take one block per contiguous stratum
-    (evenly spaced over the block sequence), picked within the stratum by
-    ``rng`` -- so the split is reproducible yet seed-sensitive, and both
-    splits sample the whole timeline instead of clustering in one region.
-    Every other block is ``train``.
+    The combined val+test *holdout* is placed one block per evenly-spaced
+    stratum over the whole block sequence, then those holdout blocks are
+    divided into val/test (also stratified). Spreading the holdout as a
+    whole -- rather than choosing val, then test, independently -- keeps
+    both splits distributed even when only one block of each is available
+    (otherwise a lone val and a lone test block often clump together and
+    leave a long train-only stretch). Picks use ``rng`` so the split is
+    reproducible yet seed-sensitive. Every non-holdout block is ``train``.
     """
 
     def pick_spread(pool, k):
@@ -736,9 +739,12 @@ def _stratified_labels(n_blocks, n_val, n_test, rng):
 
     labels = np.array(["train"] * n_blocks, dtype="<U5")
     all_idx = np.arange(n_blocks)
-    labels[pick_spread(all_idx, n_val)] = "val"
-    remaining = all_idx[labels == "train"]
-    labels[pick_spread(remaining, n_test)] = "test"
+    holdout = np.array(sorted(pick_spread(all_idx, n_val + n_test)))
+    test_slots = pick_spread(np.arange(len(holdout)), n_test)
+    is_test = np.zeros(len(holdout), dtype=bool)
+    is_test[test_slots] = True
+    labels[holdout[is_test]] = "test"
+    labels[holdout[~is_test]] = "val"
     return labels.tolist()
 
 

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -607,11 +607,10 @@ class YOLO_octron:
                         if len(common_valid) < old_count:
                             n_dropped = old_count - len(common_valid)
                             label_name = labels[entry]["label"]
-                            print(
-                                f"Warning: {n_dropped} frame(s) "
-                                f"dropped for label '{label_name}' "
-                                f"(empty polygons in at least "
-                                f"one label)"
+                            logger.warning(
+                                f"{n_dropped} frame(s) dropped for "
+                                f"label '{label_name}' (empty polygons "
+                                f"in at least one label)"
                             )
                         labels[entry]["frames"] = common_valid
             else:
@@ -624,8 +623,8 @@ class YOLO_octron:
                     if len(valid_frames) < len(frames):
                         n_dropped = len(frames) - len(valid_frames)
                         label_name = labels[entry]["label"]
-                        print(
-                            f"Warning: {n_dropped} frame(s) for label "
+                        logger.warning(
+                            f"{n_dropped} frame(s) for label "
                             f"'{label_name}' had no valid polygons "
                             f"and were excluded"
                         )
@@ -839,11 +838,10 @@ class YOLO_octron:
                         if len(common_valid) < old_count:
                             n_dropped = old_count - len(common_valid)
                             label_name = labels[entry]["label"]
-                            print(
-                                f"Warning: {n_dropped} frame(s) "
-                                f"dropped for label '{label_name}' "
-                                f"(empty bboxes in at least "
-                                f"one label)"
+                            logger.warning(
+                                f"{n_dropped} frame(s) dropped for "
+                                f"label '{label_name}' (empty bboxes "
+                                f"in at least one label)"
                             )
                         labels[entry]["frames"] = common_valid
             else:
@@ -856,8 +854,8 @@ class YOLO_octron:
                     if len(valid_frames) < len(frames):
                         n_dropped = len(frames) - len(valid_frames)
                         label_name = labels[entry]["label"]
-                        print(
-                            f"Warning: {n_dropped} frame(s) for label "
+                        logger.warning(
+                            f"{n_dropped} frame(s) for label "
                             f"'{label_name}' had no valid bounding "
                             f"boxes and were excluded"
                         )

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -936,6 +936,24 @@ class YOLO_octron:
 
                 labels[entry]["frames_split"] = split_dict
 
+    def summarize_split(self):
+        """Return structured train/val/test split report data.
+
+        See
+        :func:`octron.yolo_octron.helpers.split_report.build_split_report`
+        for the structure. Call after :meth:`prepare_split` and before
+        export (the report reads mask lengths, which export pops).
+        """
+        from octron.yolo_octron.helpers.split_report import (
+            build_split_report,
+        )
+
+        if self.label_dict is None:
+            raise ValueError(
+                "No labels found. Please run prepare_labels() first."
+            )
+        return build_split_report(self.label_dict)
+
     def create_training_data_segment(
         self,
         verbose=False,

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -158,3 +158,56 @@ def test_specs_includes_model_cache_dir(cfg_path):
     assert "model_cache_dir" in by_key
     assert by_key["model_cache_dir"].kind == "dir"
     assert by_key["model_cache_dir"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Split fractions + seed (shared by CLI defaults and the GUI)
+# ---------------------------------------------------------------------------
+
+
+def test_split_defaults(cfg_path):
+    assert config.get_split_fractions() == (0.7, 0.15)
+    assert config.get_split_seed() == 88
+
+
+def test_split_fractions_and_seed_roundtrip(cfg_path):
+    config.set_value("split_train_fraction", 0.6)
+    config.set_value("split_val_fraction", 0.2)
+    config.set_value("split_seed", 7)
+    assert config.get_split_fractions() == (0.6, 0.2)
+    assert config.get_split_seed() == 7
+
+
+def test_split_fraction_out_of_range_falls_back(cfg_path):
+    # A fraction outside (0, 1) fails validation on load and reverts to
+    # the default (a malformed file never breaks OCTRON).
+    cfg_path.write_text("split_train_fraction: 1.5\n")
+    assert config.get_value("split_train_fraction") == 0.7
+
+
+def test_split_set_value_rejects_bad_fraction(cfg_path):
+    with pytest.raises(ValueError):
+        config.set_value("split_val_fraction", 0)
+    with pytest.raises(ValueError):
+        config.set_value("split_val_fraction", 1.0)
+
+
+def test_split_set_value_rejects_negative_seed(cfg_path):
+    with pytest.raises(ValueError):
+        config.set_value("split_seed", -1)
+
+
+def test_split_fractions_no_test_room_falls_back(cfg_path):
+    # train + val >= 1 leaves no room for a test split -> defaults.
+    config.set_value("split_train_fraction", 0.7)
+    config.set_value("split_val_fraction", 0.4)
+    assert config.get_split_fractions() == (0.7, 0.15)
+
+
+def test_specs_includes_split_settings(cfg_path):
+    keys = {s.key for s in config.specs()}
+    assert {
+        "split_train_fraction",
+        "split_val_fraction",
+        "split_seed",
+    } <= keys

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -9,7 +9,14 @@ still fails before any model, label, or geometry work.
 import numpy as np
 import pytest
 
-from octron.tools.split import run_split
+from octron.tools.split import (
+    _build_frame_to_split,
+    _num_frames_for,
+    _print_split_timelines,
+    _timeline_bins,
+    run_split,
+)
+from octron.yolo_octron.helpers.training import train_test_val
 from octron.yolo_octron.yolo_octron import YOLO_octron
 
 # ---------------------------------------------------------------------------
@@ -108,7 +115,7 @@ def _split_with_seed(frames, seed):
 
 
 def test_prepare_split_is_reproducible_with_seed():
-    frames = list(range(30))
+    frames = list(range(300))
     assert _split_with_seed(frames, 123) == _split_with_seed(frames, 123)
 
 
@@ -116,5 +123,171 @@ def test_prepare_split_seed_changes_partition():
     """A different seed must change the split (regression: seed was
     ignored).
     """
-    frames = list(range(30))
+    frames = list(range(300))
     assert _split_with_seed(frames, 1) != _split_with_seed(frames, 2)
+
+
+# ---------------------------------------------------------------------------
+# train_test_val: contiguous-block split behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_ttv_partitions_disjoint_subset_nonempty():
+    frames = np.arange(500)
+    s = train_test_val(frames, 0.7, 0.15, random_seed=0)
+    train = {int(x) for x in s["train"]}
+    val = {int(x) for x in s["val"]}
+    test = {int(x) for x in s["test"]}
+    assert train and val and test
+    assert train.isdisjoint(val)
+    assert train.isdisjoint(test)
+    assert val.isdisjoint(test)
+    assert (train | val | test).issubset(set(frames.tolist()))
+
+
+def test_ttv_no_adjacent_train_val_leakage():
+    # With the default 1-frame buffer, no train frame may sit immediately
+    # next to a val frame (that would be a near-duplicate across the split).
+    frames = np.arange(500)
+    s = train_test_val(
+        frames, 0.7, 0.15, random_seed=0, block_size=20, buffer=1
+    )
+    train = {int(x) for x in s["train"]}
+    val = {int(x) for x in s["val"]}
+    for v in val:
+        assert (v - 1) not in train
+        assert (v + 1) not in train
+
+
+def test_ttv_keeps_runs_together():
+    # Contiguous-block assignment keeps adjacent frames on the same side:
+    # split crossings scale with the number of blocks, not with n (as a
+    # per-frame random split would).
+    frames = np.arange(600)
+    s = train_test_val(frames, 0.7, 0.15, random_seed=0, buffer=0)
+    label = {}
+    for name in ("train", "val", "test"):
+        for f in s[name]:
+            label[int(f)] = name
+    crossings = sum(
+        1
+        for f in range(599)
+        if f in label and (f + 1) in label and label[f] != label[f + 1]
+    )
+    assert crossings <= 40
+
+
+def test_ttv_reproducible_and_seed_sensitive():
+    frames = np.arange(500)
+    a = [x.tolist() for x in train_test_val(frames, 0.7, 0.15, 1).values()]
+    b = [x.tolist() for x in train_test_val(frames, 0.7, 0.15, 1).values()]
+    c = [x.tolist() for x in train_test_val(frames, 0.7, 0.15, 2).values()]
+    assert a == b
+    assert a != c
+
+
+def test_ttv_minimum_three_frames():
+    s = train_test_val(np.array([0, 1, 2]), 0.6, 0.2, random_seed=0)
+    assert len(s["train"]) == 1
+    assert len(s["val"]) == 1
+    assert len(s["test"]) == 1
+
+
+def test_ttv_episodes_are_balanced_across_splits():
+    # Two annotation bursts in one video separated by a large gap: each
+    # episode must appear in every split (not dominated by the denser one).
+    ep1 = np.arange(0, 100)
+    ep2 = np.arange(5000, 5040)
+    frames = np.concatenate([ep1, ep2])
+    s = train_test_val(frames, 0.7, 0.15, random_seed=0)
+    ep1_set = set(ep1.tolist())
+    ep2_set = set(ep2.tolist())
+    for split in ("train", "val", "test"):
+        present = {int(x) for x in s[split]}
+        assert present & ep1_set, f"episode 1 missing from {split}"
+        assert present & ep2_set, f"episode 2 missing from {split}"
+
+
+def test_ttv_tiny_episode_goes_to_train_only():
+    main = np.arange(0, 100)
+    tiny = np.array([9000, 9001])  # 2 frames: too small to split 3 ways
+    frames = np.concatenate([main, tiny])
+    s = train_test_val(frames, 0.7, 0.15, random_seed=0)
+    train = {int(x) for x in s["train"]}
+    val = {int(x) for x in s["val"]}
+    test = {int(x) for x in s["test"]}
+    assert {9000, 9001} <= train
+    assert not ({9000, 9001} & (val | test))
+
+
+# ---------------------------------------------------------------------------
+# Terminal split-timeline visualization helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeMask:
+    """Minimal stand-in for a zarr mask array (only ``.shape`` is used)."""
+
+    def __init__(self, num_frames):
+        self.shape = (num_frames, 4, 4)
+
+
+def _labels_with_split(num_frames=200):
+    """One-label subfolder dict shaped like collect_labels output."""
+    return {
+        "video": None,
+        "video_file_path": None,
+        0: {
+            "label": "a",
+            "masks": [_FakeMask(num_frames)],
+            "frames": np.arange(0, 60),
+            "frames_split": {
+                "train": np.arange(0, 40),
+                "val": np.arange(40, 50),
+                "test": np.arange(50, 60),
+            },
+        },
+    }
+
+
+def test_build_frame_to_split_aggregates_and_skips_meta():
+    mapping = _build_frame_to_split(_labels_with_split())
+    assert mapping[0] == "train"
+    assert mapping[45] == "val"
+    assert mapping[59] == "test"
+    # Meta keys must never appear as frames.
+    assert all(isinstance(k, int) for k in mapping)
+    assert len(mapping) == 60
+
+
+def test_num_frames_prefers_mask_shape():
+    labels = _labels_with_split(num_frames=321)
+    assert _num_frames_for(labels, _build_frame_to_split(labels)) == 321
+
+
+def test_num_frames_falls_back_to_max_index():
+    labels = {0: {"label": "a", "frames_split": {"train": [3, 7]}}}
+    assert _num_frames_for(labels, _build_frame_to_split(labels)) == 8
+
+
+def test_timeline_bins_dominant_and_empty():
+    # Frames only in the first half -> back half must be unannotated (None).
+    frame_to_split = {i: "train" for i in range(50)}
+    bins = _timeline_bins(frame_to_split, num_frames=100, width=10)
+    assert len(bins) == 10
+    assert bins[0] == "train"
+    assert bins[-1] is None
+
+
+def test_render_timeline_smoke(capsys):
+    _print_split_timelines({"proj/sub": _labels_with_split()})
+    out = capsys.readouterr().out
+    assert "Timeline: sub" in out
+    assert "200 frames, 60 annotated" in out
+    assert "train" in out and "val" in out and "test" in out
+    assert "unannotated" in out
+
+
+def test_render_timeline_noop_without_split():
+    # No frames_split -> nothing to render, and no exception.
+    _print_split_timelines({"proj/sub": {0: {"label": "a"}}})

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -13,6 +13,7 @@ from octron.tools.split import (
     _build_frame_to_split,
     _num_frames_for,
     _print_split_timelines,
+    _segment_episodes,
     _timeline_bins,
     run_split,
 )
@@ -279,13 +280,55 @@ def test_timeline_bins_dominant_and_empty():
     assert bins[-1] is None
 
 
+def _labels_two_episodes(num_frames=10000):
+    """Two annotation bursts separated by a large unannotated gap."""
+    ep1 = np.arange(0, 100)
+    ep2 = np.arange(5000, 5050)
+    frames = np.concatenate([ep1, ep2])
+    n = len(frames)
+    return {
+        "video": None,
+        "video_file_path": None,
+        0: {
+            "label": "a",
+            "masks": [_FakeMask(num_frames)],
+            "frames": frames,
+            "frames_split": {
+                "train": frames[: int(n * 0.7)],
+                "val": frames[int(n * 0.7) : int(n * 0.85)],
+                "test": frames[int(n * 0.85) :],
+            },
+        },
+    }
+
+
+def test_segment_episodes_splits_on_large_gap():
+    assert _segment_episodes([0, 1, 2, 100, 101], gap=10) == [
+        [0, 1, 2],
+        [100, 101],
+    ]
+
+
+def test_segment_episodes_single_when_dense():
+    assert _segment_episodes([0, 3, 6, 9], gap=10) == [[0, 3, 6, 9]]
+
+
 def test_render_timeline_smoke(capsys):
     _print_split_timelines({"proj/sub": _labels_with_split()})
     out = capsys.readouterr().out
     assert "Timeline: sub" in out
-    assert "200 frames, 60 annotated" in out
+    assert "200 frames, 60 annotated, 1 episode(s)" in out
     assert "train" in out and "val" in out and "test" in out
     assert "unannotated" in out
+
+
+def test_render_timeline_compresses_gaps(capsys):
+    # Two far-apart episodes: the empty middle must collapse to an
+    # ellipsis and the header must report both episodes.
+    _print_split_timelines({"proj/sub": _labels_two_episodes()})
+    out = capsys.readouterr().out
+    assert "2 episode(s)" in out
+    assert "\u2026" in out  # elided gap marker
 
 
 def test_render_timeline_noop_without_split():

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -9,14 +9,15 @@ still fails before any model, label, or geometry work.
 import numpy as np
 import pytest
 
-from octron.tools.split import (
+from octron.tools.split import run_split
+from octron.yolo_octron.helpers.split_report import (
     _annotated_frame_count,
     _build_frame_to_split,
     _num_frames_for,
-    _print_split_timelines,
     _segment_episodes,
     _timeline_bins,
-    run_split,
+    build_split_report,
+    render_split_report,
 )
 from octron.yolo_octron.helpers.training import train_test_val
 from octron.yolo_octron.yolo_octron import YOLO_octron
@@ -330,7 +331,9 @@ def test_segment_episodes_single_when_dense():
 
 
 def test_render_timeline_smoke(capsys):
-    _print_split_timelines({"proj/sub": _labels_with_split()})
+    render_split_report(
+        build_split_report({"proj/sub": _labels_with_split()}), 88
+    )
     out = capsys.readouterr().out
     assert "Timeline: sub" in out
     assert "200 frames, 60 assigned, 0 buffered, 1 episode(s)" in out
@@ -341,7 +344,9 @@ def test_render_timeline_smoke(capsys):
 def test_render_timeline_compresses_gaps(capsys):
     # Two far-apart episodes: the empty middle must collapse to an
     # ellipsis and the header must report both episodes.
-    _print_split_timelines({"proj/sub": _labels_two_episodes()})
+    render_split_report(
+        build_split_report({"proj/sub": _labels_two_episodes()}), 88
+    )
     out = capsys.readouterr().out
     assert "2 episode(s)" in out
     assert "\u2026" in out  # elided gap marker
@@ -372,11 +377,35 @@ def test_render_timeline_reports_buffered(capsys):
             },
         },
     }
-    _print_split_timelines({"proj/sub": labels})
+    render_split_report(build_split_report({"proj/sub": labels}), 88)
     out = capsys.readouterr().out
     assert "9 assigned, 1 buffered" in out
 
 
 def test_render_timeline_noop_without_split():
-    # No frames_split -> nothing to render, and no exception.
-    _print_split_timelines({"proj/sub": {0: {"label": "a"}}})
+    # No frames_split -> no timeline rendered, and no exception.
+    render_split_report(
+        build_split_report({"proj/sub": {0: {"label": "a"}}}), 88
+    )
+
+
+def test_build_split_report_structure():
+    report = build_split_report({"proj/sub": _labels_with_split()})
+    assert len(report) == 1
+    sub = report[0]
+    assert sub["name"] == "sub"
+    assert sub["rows"] == [("a", 40, 10, 10, 60)]
+    tl = sub["timeline"]
+    assert tl["num_frames"] == 200
+    assert tl["assigned"] == 60
+    assert tl["buffered"] == 0
+    assert tl["n_episodes"] == 1
+
+
+def test_summarize_split_via_core_matches_build():
+    # YOLO_octron.summarize_split() is a thin wrapper over build_split_report.
+    obj = YOLO_octron.__new__(YOLO_octron)
+    obj.label_dict = {"proj/sub": _labels_with_split()}
+    report = obj.summarize_split()
+    assert report[0]["rows"] == [("a", 40, 10, 10, 60)]
+    assert report[0]["timeline"]["assigned"] == 60

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from octron.tools.split import (
+    _annotated_frame_count,
     _build_frame_to_split,
     _num_frames_for,
     _print_split_timelines,
@@ -317,7 +318,7 @@ def test_render_timeline_smoke(capsys):
     _print_split_timelines({"proj/sub": _labels_with_split()})
     out = capsys.readouterr().out
     assert "Timeline: sub" in out
-    assert "200 frames, 60 annotated, 1 episode(s)" in out
+    assert "200 frames, 60 assigned, 0 buffered, 1 episode(s)" in out
     assert "train" in out and "val" in out and "test" in out
     assert "unannotated" in out
 
@@ -329,6 +330,36 @@ def test_render_timeline_compresses_gaps(capsys):
     out = capsys.readouterr().out
     assert "2 episode(s)" in out
     assert "\u2026" in out  # elided gap marker
+
+
+def test_annotated_frame_count_unions_labels():
+    labels = {
+        "video": None,
+        0: {"label": "a", "frames": np.array([0, 1, 2])},
+        1: {"label": "b", "frames": np.array([2, 3])},
+    }
+    assert _annotated_frame_count(labels) == 4  # {0, 1, 2, 3}
+
+
+def test_render_timeline_reports_buffered(capsys):
+    # 10 annotated frames but only 9 assigned to a split -> 1 buffered.
+    labels = {
+        "video": None,
+        "video_file_path": None,
+        0: {
+            "label": "a",
+            "masks": [_FakeMask(50)],
+            "frames": np.arange(0, 10),
+            "frames_split": {
+                "train": np.array([0, 1, 2, 3, 4, 5]),
+                "val": np.array([6, 7]),
+                "test": np.array([8]),
+            },
+        },
+    }
+    _print_split_timelines({"proj/sub": labels})
+    out = capsys.readouterr().out
+    assert "9 assigned, 1 buffered" in out
 
 
 def test_render_timeline_noop_without_split():

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -195,31 +195,46 @@ def test_ttv_minimum_three_frames():
     assert len(s["test"]) == 1
 
 
-def test_ttv_episodes_are_balanced_across_splits():
-    # Two annotation bursts in one video separated by a large gap: each
-    # episode must appear in every split (not dominated by the denser one).
-    ep1 = np.arange(0, 100)
-    ep2 = np.arange(5000, 5040)
-    frames = np.concatenate([ep1, ep2])
+def test_ttv_global_proportions_multi_episode():
+    # Several episodes must not inflate val/test: the realized split should
+    # track the requested 70/15/15 globally (regression: the old
+    # per-episode allocation forced >=1 val + >=1 test block per episode,
+    # skewing short/many-episode videos toward ~55/22/22 or worse).
+    eps = [np.arange(i * 10000, i * 10000 + 300) for i in range(4)]
+    frames = np.concatenate(eps)
     s = train_test_val(frames, 0.7, 0.15, random_seed=0)
-    ep1_set = set(ep1.tolist())
-    ep2_set = set(ep2.tolist())
-    for split in ("train", "val", "test"):
-        present = {int(x) for x in s[split]}
-        assert present & ep1_set, f"episode 1 missing from {split}"
-        assert present & ep2_set, f"episode 2 missing from {split}"
+    tot = sum(len(s[k]) for k in ("train", "val", "test"))
+    frac = {k: len(s[k]) / tot for k in ("train", "val", "test")}
+    assert abs(frac["train"] - 0.70) < 0.06, frac["train"]
+    assert abs(frac["val"] - 0.15) < 0.06, frac["val"]
+    assert abs(frac["test"] - 0.15) < 0.06, frac["test"]
 
 
-def test_ttv_tiny_episode_goes_to_train_only():
-    main = np.arange(0, 100)
-    tiny = np.array([9000, 9001])  # 2 frames: too small to split 3 ways
+def test_ttv_valtest_spread_across_timeline():
+    # Stratified selection keeps val and test spread across the whole
+    # timeline rather than clustered in one region.
+    frames = np.arange(2000)
+    s = train_test_val(frames, 0.7, 0.15, random_seed=0)
+    for name in ("val", "test"):
+        arr = np.sort(np.asarray(s[name], dtype=int))
+        assert arr[-1] - arr[0] > 0.6 * 2000, f"{name} span {arr[-1] - arr[0]}"
+
+
+def test_ttv_tiny_episode_stays_together():
+    # A tiny (near-duplicate) episode is one atomic block, so both its
+    # frames land in the SAME split -- never divided across train/val/test.
+    main = np.arange(0, 400)
+    tiny = np.array([9000, 9001])
     frames = np.concatenate([main, tiny])
     s = train_test_val(frames, 0.7, 0.15, random_seed=0)
-    train = {int(x) for x in s["train"]}
-    val = {int(x) for x in s["val"]}
-    test = {int(x) for x in s["test"]}
-    assert {9000, 9001} <= train
-    assert not ({9000, 9001} & (val | test))
+    holders = {
+        name
+        for name in ("train", "val", "test")
+        if {9000, 9001} & {int(x) for x in s[name]}
+    }
+    assert len(holders) == 1
+    only = holders.pop()
+    assert {9000, 9001} <= {int(x) for x in s[only]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors how data split parameters (train/test/val fractions and seed) are handled across the CLI, GUI, and core logic. 

## Why
OCTRON's old `train_test_val` was a fully random per-frame shuffle. Because SAM propagation fills in long runs of near-identical frames, random splitting scattered those near-duplicates across train/val/test - so the model was effectively validated/tested on frames it had trained on, and metrics looked better than they were. On top of that the split was invisible (no way to see what it did), the GUI hard-coded the fractions/seed.

## What changed
**Splitting logic (`helpers/training.py`)**
- Replaced the random per-frame shuffle with an **episode-aware, contiguous-block split**: annotated frames are grouped into *episodes* (bursts separated by large temporal gaps), each episode is cut into short contiguous blocks, whole blocks go to train/val/test, and a 1-frame *buffer* is dropped where a train block meets a val/test block. Near-duplicate neighbours stay on the same side → no leakage.
- **Global budget + stratified holdout**: allocation runs across the *whole* video so realized proportions track the requested fractions, for example 70/15/15 for train/test/val fraction. val/test blocks are chosen *stratified* so they stay spread across the timeline; tiny episodes stay atomic (both frames land in one split).

**Split visibility (new `helpers/split_report.py`)**
- Prints a **summary table** (per subfolder/label) and a **colored timeline** of where train/val/test fall across the whole video - long unannotated gaps compress to ` … `, and the header reports frames / assigned / buffered / episodes. See screenshot below. 

**One split path for CLI + GUI**
- The report is a shared unit (`build_split_report` + `render_split_report`) exposed via `YOLO_octron.summarize_split()`, so `octron split` and the GUI render the **identical** report (was CLI-only).
- Split **fractions + seed now live in `config.yaml`** (`split_train_fraction` / `split_val_fraction` / `split_seed`). CLI `--train/--val/--seed` default to those (flag > config > default); the GUI uses the same config. One source of truth.

Minor improvement: **Windows progress bars (`_logging.py`, `tools/split.py`)**
- Routed logging through `tqdm.write` and dropped the competing CLI progress writer, so tqdm bars no longer staircase onto new lines.

## Where
- Core: `helpers/training.py`, new `helpers/split_report.py`, `yolo_octron.py` (`summarize_split`)
- CLI / GUI / config: `tools/split.py`, `tools/train.py`, `cli.py`, `gui/yolo_handler.py`, `config.py`, `_logging.py`
- Tests: `tests/test_unit/test_split_utils.py`, `tests/test_unit/test_config.py`

## Validation
Full `pre-commit` (ruff, mypy, codespell, check-manifest) + `pytest` all green. Docs updated in OCTRON-docs#8.

Co-Authored-By: Oz <oz-agent@warp.dev>

<img width="728" height="656" alt="Screenshot 2026-09-07 at 15 03 20" src="https://github.com/user-attachments/assets/b89f51a8-ec03-426b-bc62-09edb91b589d" />
