### PR TITLE
CLI/GUI parity for data splitting + multi-class split fix

### DIFF
--- a/octron/cli.py
+++ b/octron/cli.py
@@ -277,6 +277,14 @@ def split(
         "--seed",
         help="Random seed for reproducibility (default: config.yaml).",
     ),
+    buffer: int | None = typer.Option(
+        None,
+        "--buffer",
+        help=(
+            "Frames dropped at each split block boundary for a temporal "
+            "gap between train/val/test (default: config.yaml)."
+        ),
+    ),
     prune: bool = typer.Option(
         False,
         "--prune/--no-prune",
@@ -305,6 +313,7 @@ def split(
         train_fraction=train_fraction,
         val_fraction=val_fraction,
         seed=seed,
+        buffer=buffer,
         prune=prune,
         watershed=watershed,
         train_mode=train_mode,
@@ -372,6 +381,14 @@ def train(
             "with --no-split)."
         ),
     ),
+    buffer: int | None = typer.Option(
+        None,
+        "--buffer",
+        help=(
+            "Frames dropped at each split block boundary (default: "
+            "config.yaml; ignored with --no-split)."
+        ),
+    ),
     prune: bool = typer.Option(
         False,
         "--prune/--no-prune",
@@ -409,6 +426,7 @@ def train(
         train_fraction=train_fraction,
         val_fraction=val_fraction,
         seed=seed,
+        buffer=buffer,
         prune=prune,
         watershed=watershed,
     )

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -277,6 +277,22 @@ def split(
         "--seed",
         help="Random seed for reproducibility (default: config.yaml).",
     ),
+    prune: bool = typer.Option(
+        False,
+        "--prune/--no-prune",
+        help=(
+            "Drop frames where not all labels are annotated "
+            "(default: off, matching the GUI)."
+        ),
+    ),
+    watershed: bool = typer.Option(
+        False,
+        "--watershed/--no-watershed",
+        help=(
+            "Watershed touching same-label masks into separate "
+            "instances (default: off)."
+        ),
+    ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print split sizes without writing files."
     ),
@@ -289,6 +305,8 @@ def split(
         train_fraction=train_fraction,
         val_fraction=val_fraction,
         seed=seed,
+        prune=prune,
+        watershed=watershed,
         train_mode=train_mode,
         dry_run=dry_run,
     )
@@ -354,6 +372,22 @@ def train(
             "with --no-split)."
         ),
     ),
+    prune: bool = typer.Option(
+        False,
+        "--prune/--no-prune",
+        help=(
+            "Drop frames where not all labels are annotated "
+            "(default: off; ignored with --no-split)."
+        ),
+    ),
+    watershed: bool = typer.Option(
+        False,
+        "--watershed/--no-watershed",
+        help=(
+            "Watershed touching same-label masks into separate "
+            "instances (default: off; ignored with --no-split)."
+        ),
+    ),
 ):
     (
         """Prepare training data and run YOLO model training on an """
@@ -375,6 +409,8 @@ def train(
         train_fraction=train_fraction,
         val_fraction=val_fraction,
         seed=seed,
+        prune=prune,
+        watershed=watershed,
     )
 
 

--- a/octron/config.py
+++ b/octron/config.py
@@ -178,6 +178,17 @@ SETTINGS: "tuple[SettingSpec, ...]" = (
         ),
         coerce=_coerce_nonneg_int,
     ),
+    SettingSpec(
+        key="split_buffer",
+        default=1,
+        kind="int",
+        description=(
+            "Frames dropped at each train/val/test block boundary to add a "
+            "temporal gap between splits (0 disables). Used when --buffer "
+            "is omitted, and by the GUI."
+        ),
+        coerce=_coerce_nonneg_int,
+    ),
 )
 
 _SPECS = {spec.key: spec for spec in SETTINGS}
@@ -395,3 +406,8 @@ def get_split_fractions() -> "tuple[float, float]":
 def get_split_seed() -> int:
     """Return the random seed for the train/val/test split."""
     return get_value("split_seed")
+
+
+def get_split_buffer() -> int:
+    """Return the buffer (frames dropped at split block boundaries)."""
+    return get_value("split_buffer")

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -17,6 +17,7 @@ def run_split(
     train_fraction=None,
     val_fraction=None,
     seed=None,
+    buffer=None,
     prune=False,
     watershed=False,
     train_mode="segment",
@@ -45,6 +46,10 @@ def run_split(
     seed : int or None
         Random seed for reproducibility. ``None`` reads ``split_seed``
         from config.
+    buffer : int or None
+        Frames dropped at each train/val/test block boundary to add a
+        temporal gap between splits. ``None`` (the CLI default) reads
+        ``split_buffer`` from ``config.yaml``.
     prune : bool
         Drop frames where not all labels are annotated (threaded to
         ``prepare_labels(prune_empty_labels=...)``). Default ``False``,
@@ -68,7 +73,12 @@ def run_split(
     # Resolve unset split parameters from config.yaml. Precedence: a CLI
     # flag (non-None) overrides config, which overrides the built-in
     # default. The GUI reads the same config for its defaults.
-    if train_fraction is None or val_fraction is None or seed is None:
+    if (
+        train_fraction is None
+        or val_fraction is None
+        or seed is None
+        or buffer is None
+    ):
         from octron import config
 
         if train_fraction is None or val_fraction is None:
@@ -79,6 +89,8 @@ def run_split(
                 val_fraction = cfg_val
         if seed is None:
             seed = config.get_split_seed()
+        if buffer is None:
+            buffer = config.get_split_buffer()
 
     # Validate fractions up front using the core guard (also enforced
     # inside prepare_split) so the CLI fails before any model, label, or
@@ -116,6 +128,7 @@ def run_split(
         training_fraction=train_fraction,
         validation_fraction=val_fraction,
         random_seed=seed,
+        buffer=buffer,
     )
 
     # Print summary table + colored whole-video timelines (shared w/ GUI)

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -17,6 +17,8 @@ def run_split(
     train_fraction=None,
     val_fraction=None,
     seed=None,
+    prune=False,
+    watershed=False,
     train_mode="segment",
     dry_run=False,
 ):
@@ -43,6 +45,13 @@ def run_split(
     seed : int or None
         Random seed for reproducibility. ``None`` reads ``split_seed``
         from config.
+    prune : bool
+        Drop frames where not all labels are annotated (threaded to
+        ``prepare_labels(prune_empty_labels=...)``). Default ``False``,
+        matching the GUI's Prune checkbox.
+    watershed : bool
+        Watershed touching same-label masks into separate instances
+        before geometry generation. Default ``False``.
     train_mode : str
         ``'segment'`` for instance segmentation, ``'detect'`` for bounding-box
         detection only.
@@ -81,10 +90,11 @@ def run_split(
         project_path=project_path,
     )
     yolo.train_mode = train_mode
+    yolo.enable_watershed = watershed
 
     # --- Step 1: collect labels ---
     print("Preparing labels...")
-    yolo.prepare_labels()
+    yolo.prepare_labels(prune_empty_labels=prune)
 
     # --- Step 2: generate geometry (polygons for segment, bboxes for
     # detect) ---

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -26,6 +26,7 @@ def run_training(
     train_fraction=None,
     val_fraction=None,
     seed=None,
+    buffer=None,
     prune=False,
     watershed=False,
 ):
@@ -69,6 +70,9 @@ def run_training(
     seed : int or None
         Random seed for the split. ``None`` reads ``config.yaml``
         (ignored when ``skip_split=True``).
+    buffer : int or None
+        Frames dropped at each train/val/test block boundary. ``None``
+        reads ``config.yaml`` (ignored when ``skip_split=True``).
     prune : bool
         Drop frames where not all labels are annotated (ignored when
         ``skip_split=True``). Default ``False``.
@@ -115,6 +119,7 @@ def run_training(
             train_fraction=train_fraction,
             val_fraction=val_fraction,
             seed=seed,
+            buffer=buffer,
             prune=prune,
             watershed=watershed,
             train_mode=train_mode,

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -26,6 +26,8 @@ def run_training(
     train_fraction=None,
     val_fraction=None,
     seed=None,
+    prune=False,
+    watershed=False,
 ):
     """Run the OCTRON/YOLO training pipeline.
 
@@ -67,6 +69,12 @@ def run_training(
     seed : int or None
         Random seed for the split. ``None`` reads ``config.yaml``
         (ignored when ``skip_split=True``).
+    prune : bool
+        Drop frames where not all labels are annotated (ignored when
+        ``skip_split=True``). Default ``False``.
+    watershed : bool
+        Watershed touching same-label masks into separate instances
+        (ignored when ``skip_split=True``). Default ``False``.
 
     """
     from octron.test_gpu import auto_device
@@ -107,6 +115,8 @@ def run_training(
             train_fraction=train_fraction,
             val_fraction=val_fraction,
             seed=seed,
+            prune=prune,
+            watershed=watershed,
             train_mode=train_mode,
             dry_run=False,
         )

--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -623,10 +623,10 @@ class YoloHandler(QObject):
     def _split_and_report(self):
         """Split train/val/test from config and print the shared report.
 
-        Reads the split fractions/seed from ``config.yaml`` (the same
-        source the CLI defaults to) and prints the shared summary table +
-        colored timeline to the terminal that launched napari, so the GUI
-        and CLI show an identical split report.
+        Reads the split fractions/seed/buffer from ``config.yaml`` (the
+        same source the CLI defaults to) and prints the shared summary
+        table + colored timeline to the terminal that launched napari, so
+        the GUI and CLI show an identical split report.
         """
         from octron import config
         from octron.yolo_octron.helpers.split_report import (
@@ -635,10 +635,12 @@ class YoloHandler(QObject):
 
         train_frac, val_frac = config.get_split_fractions()
         seed = config.get_split_seed()
+        buffer = config.get_split_buffer()
         self.yolo.prepare_split(
             training_fraction=train_frac,
             validation_fraction=val_frac,
             random_seed=seed,
+            buffer=buffer,
         )
         render_split_report(self.yolo.summarize_split(), seed)
 

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -121,19 +121,19 @@ def find_common_frames(frame_arrays):
 
 
 def prune_frames_by_geometry(labels, prune_empty_labels, geometry_key):
-    """Drop frames whose geometry (``geometry_key``) came out empty.
+    """Drop frames whose geometry (geometry_key) came out empty.
 
-    ``geometry_key`` is ``"polygons"`` (segment) or ``"bboxes"``
-    (detect). A frame is *valid* for a label when
-    ``labels[label][geometry_key][frame]`` is a non-empty list (i.e. the
-    mask produced at least one polygon/bounding box).
+    geometry_key is "polygons" (segment) or "bboxes" (detect). A frame is
+    valid for a label when labels[label][geometry_key][frame] is a
+    non-empty list (i.e. the mask produced at least one polygon/bounding
+    box).
 
-    With ``prune_empty_labels=True`` the kept set is the **cross-label
-    intersection** of valid frames, so every label shares one frame set
-    and no near-duplicate frame ends up on opposite sides of the
-    train/val/test split. With ``prune_empty_labels=False`` each label is
-    pruned independently. Mutates ``labels`` in place, rewriting
-    ``labels[label]["frames"]``.
+    With prune_empty_labels=True the kept set is the cross-label
+    intersection of valid frames, so every label shares one frame set and
+    no near-duplicate frame ends up on opposite sides of the
+    train/val/test split. With prune_empty_labels=False each label is
+    pruned independently. Mutates labels in place, rewriting
+    labels[label]["frames"].
     """
     entries = [e for e in labels if e not in ("video", "video_file_path")]
     noun = "bounding boxes" if geometry_key == "bboxes" else geometry_key

--- a/octron/yolo_octron/helpers/training.py
+++ b/octron/yolo_octron/helpers/training.py
@@ -120,6 +120,62 @@ def find_common_frames(frame_arrays):
     return common
 
 
+def prune_frames_by_geometry(labels, prune_empty_labels, geometry_key):
+    """Drop frames whose geometry (``geometry_key``) came out empty.
+
+    ``geometry_key`` is ``"polygons"`` (segment) or ``"bboxes"``
+    (detect). A frame is *valid* for a label when
+    ``labels[label][geometry_key][frame]`` is a non-empty list (i.e. the
+    mask produced at least one polygon/bounding box).
+
+    With ``prune_empty_labels=True`` the kept set is the **cross-label
+    intersection** of valid frames, so every label shares one frame set
+    and no near-duplicate frame ends up on opposite sides of the
+    train/val/test split. With ``prune_empty_labels=False`` each label is
+    pruned independently. Mutates ``labels`` in place, rewriting
+    ``labels[label]["frames"]``.
+    """
+    entries = [e for e in labels if e not in ("video", "video_file_path")]
+    noun = "bounding boxes" if geometry_key == "bboxes" else geometry_key
+    if prune_empty_labels:
+        valid_per_label = []
+        for entry in entries:
+            geom = labels[entry].get(geometry_key, {})
+            valid_per_label.append(
+                {
+                    int(f)
+                    for f in labels[entry]["frames"]
+                    if len(geom.get(f, [])) > 0
+                }
+            )
+        if not valid_per_label:
+            return
+        common_valid = np.array(sorted(set.intersection(*valid_per_label)))
+        for entry in entries:
+            old_count = len(labels[entry]["frames"])
+            if len(common_valid) < old_count:
+                logger.warning(
+                    f"{old_count - len(common_valid)} frame(s) dropped for "
+                    f"label '{labels[entry]['label']}' (empty "
+                    f"{geometry_key} in at least one label)"
+                )
+            labels[entry]["frames"] = common_valid
+    else:
+        for entry in entries:
+            frames = labels[entry]["frames"]
+            geom = labels[entry].get(geometry_key, {})
+            valid_frames = np.array(
+                [f for f in frames if len(geom.get(f, [])) > 0]
+            )
+            if len(valid_frames) < len(frames):
+                logger.warning(
+                    f"{len(frames) - len(valid_frames)} frame(s) for label "
+                    f"'{labels[entry]['label']}' had no valid {noun} "
+                    f"and were excluded"
+                )
+                labels[entry]["frames"] = valid_frames
+
+
 def pick_random_frames(frames, n=20):
     """Pick n random frames from a frames array without replacement.
 

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -821,13 +821,19 @@ class YOLO_octron:
         training_fraction=0.7,
         validation_fraction=0.15,
         random_seed=88,
+        buffer=1,
         verbose=False,
     ):
-        """Split frame indices into training, testing, and validation sets.
+        """Split frames into train/val/test, consistently across labels.
 
-        Uses train_test_val() to split the frame indices based on the
-        fractions provided. ``random_seed`` controls the shuffling so
-        splits are reproducible.
+        The split is decided once per frame over the union of all labels'
+        frames in each subfolder (via train_test_val), then each label's
+        frames_split is derived by filtering that one assignment to the
+        label's own frames. This keeps a frame in the SAME split for every
+        label (no cross-label leakage) regardless of pruning; pruning only
+        controls which frames are in the pool. random_seed makes the split
+        reproducible. buffer sets how many frames are dropped at each
+        train/val/test block boundary (forwarded to train_test_val).
         """
         self._validate_split_fractions(training_fraction, validation_fraction)
         if self.label_dict is None:
@@ -836,20 +842,47 @@ class YOLO_octron:
             )
 
         for labels in self.label_dict.values():
-            for entry in labels:
-                if entry == "video" or entry == "video_file_path":
-                    continue
-                # label = labels[entry]['label']
-                frames = labels[entry]["frames"]
-                split_dict = train_test_val(
-                    frames,
-                    training_fraction=training_fraction,
-                    validation_fraction=validation_fraction,
-                    random_seed=random_seed,
-                    verbose=verbose,
+            entries = [
+                e for e in labels if e not in ("video", "video_file_path")
+            ]
+            if not entries:
+                continue
+            # One split decision per frame over the union of every label's
+            # frames, so a frame shared by multiple labels always lands in
+            # the same split. A per-label split would otherwise send the
+            # same frame to train for one class and val for another,
+            # duplicating the image across split folders on export.
+            all_frames = np.unique(
+                np.concatenate(
+                    [np.asarray(labels[e]["frames"]) for e in entries]
                 )
+            )
+            union_split = train_test_val(
+                all_frames,
+                training_fraction=training_fraction,
+                validation_fraction=validation_fraction,
+                random_seed=random_seed,
+                buffer=buffer,
+                verbose=verbose,
+            )
+            frame_to_split = {}
+            for split_name in ("train", "val", "test"):
+                for f in union_split[split_name]:
+                    frame_to_split[int(f)] = split_name
 
-                labels[entry]["frames_split"] = split_dict
+            # Derive each label's split by filtering the global assignment
+            # to that label's frames. Buffered frames (dropped at block
+            # boundaries) map to nothing and are excluded everywhere.
+            for entry in entries:
+                buckets = {"train": [], "val": [], "test": []}
+                for f in labels[entry]["frames"]:
+                    split_name = frame_to_split.get(int(f))
+                    if split_name is not None:
+                        buckets[split_name].append(int(f))
+                labels[entry]["frames_split"] = {
+                    k: np.array(v, dtype=all_frames.dtype)
+                    for k, v in buckets.items()
+                }
 
     def summarize_split(self):
         """Return structured train/val/test split report data.

--- a/octron/yolo_octron/yolo_octron.py
+++ b/octron/yolo_octron/yolo_octron.py
@@ -56,6 +56,7 @@ from octron.yolo_octron.helpers.polygons import (
 from octron.yolo_octron.helpers.training import (
     collect_labels,
     pick_random_frames,
+    prune_frames_by_geometry,
     train_test_val,
 )
 from octron.yolo_octron.helpers.yolo_checks import check_yolo_models
@@ -580,55 +581,12 @@ class YOLO_octron:
 
                 labels[entry]["polygons"] = polys
 
-            # Prune frames that produced no valid polygons.
-            # When prune_empty_labels is True, use cross-label intersection
-            # to keep frame sets synchronized (prevents train/val/test
-            # data leakage).
-            # Otherwise, prune each label independently.
-            label_entries = [
-                e for e in labels if e not in ("video", "video_file_path")
-            ]
-            if self.prune_empty_labels:
-                valid_per_label = []
-                for entry in label_entries:
-                    polys = labels[entry].get("polygons", {})
-                    valid = {
-                        int(f)
-                        for f in labels[entry]["frames"]
-                        if len(polys.get(f, [])) > 0
-                    }
-                    valid_per_label.append(valid)
-                if valid_per_label:
-                    common_valid = np.array(
-                        sorted(set.intersection(*valid_per_label))
-                    )
-                    for entry in label_entries:
-                        old_count = len(labels[entry]["frames"])
-                        if len(common_valid) < old_count:
-                            n_dropped = old_count - len(common_valid)
-                            label_name = labels[entry]["label"]
-                            logger.warning(
-                                f"{n_dropped} frame(s) dropped for "
-                                f"label '{label_name}' (empty polygons "
-                                f"in at least one label)"
-                            )
-                        labels[entry]["frames"] = common_valid
-            else:
-                for entry in label_entries:
-                    frames = labels[entry]["frames"]
-                    polys = labels[entry].get("polygons", {})
-                    valid_frames = np.array(
-                        [f for f in frames if len(polys.get(f, [])) > 0]
-                    )
-                    if len(valid_frames) < len(frames):
-                        n_dropped = len(frames) - len(valid_frames)
-                        label_name = labels[entry]["label"]
-                        logger.warning(
-                            f"{n_dropped} frame(s) for label "
-                            f"'{label_name}' had no valid polygons "
-                            f"and were excluded"
-                        )
-                        labels[entry]["frames"] = valid_frames
+            # Drop frames whose polygons came out empty (cross-label
+            # intersection when pruning, else per label). Shared with
+            # prepare_bboxes via prune_frames_by_geometry.
+            prune_frames_by_geometry(
+                labels, self.prune_empty_labels, "polygons"
+            )
 
     def prepare_bboxes(self):
         """Calculate bounding boxes for each mask in each label of label_dict.
@@ -814,52 +772,9 @@ class YOLO_octron:
 
                 labels[entry]["bboxes"] = bboxes_dict
 
-            # Prune frames that produced no valid bounding boxes.
-            # Same cross-label vs per-label logic as prepare_polygons.
-            label_entries = [
-                e for e in labels if e not in ("video", "video_file_path")
-            ]
-            if self.prune_empty_labels:
-                valid_per_label = []
-                for entry in label_entries:
-                    bboxes = labels[entry].get("bboxes", {})
-                    valid = {
-                        int(f)
-                        for f in labels[entry]["frames"]
-                        if len(bboxes.get(f, [])) > 0
-                    }
-                    valid_per_label.append(valid)
-                if valid_per_label:
-                    common_valid = np.array(
-                        sorted(set.intersection(*valid_per_label))
-                    )
-                    for entry in label_entries:
-                        old_count = len(labels[entry]["frames"])
-                        if len(common_valid) < old_count:
-                            n_dropped = old_count - len(common_valid)
-                            label_name = labels[entry]["label"]
-                            logger.warning(
-                                f"{n_dropped} frame(s) dropped for "
-                                f"label '{label_name}' (empty bboxes "
-                                f"in at least one label)"
-                            )
-                        labels[entry]["frames"] = common_valid
-            else:
-                for entry in label_entries:
-                    frames = labels[entry]["frames"]
-                    bboxes = labels[entry].get("bboxes", {})
-                    valid_frames = np.array(
-                        [f for f in frames if len(bboxes.get(f, [])) > 0]
-                    )
-                    if len(valid_frames) < len(frames):
-                        n_dropped = len(frames) - len(valid_frames)
-                        label_name = labels[entry]["label"]
-                        logger.warning(
-                            f"{n_dropped} frame(s) for label "
-                            f"'{label_name}' had no valid bounding "
-                            f"boxes and were excluded"
-                        )
-                        labels[entry]["frames"] = valid_frames
+            # Drop frames whose bboxes came out empty (shared with
+            # prepare_polygons via prune_frames_by_geometry).
+            prune_frames_by_geometry(labels, self.prune_empty_labels, "bboxes")
 
     def prepare_geometry(self):
         """Generate training geometry, dispatching on ``self.train_mode``.

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -7,11 +7,11 @@ Covered subcommands and flags
 ------------------------------
 gui         --help
 gpu-test    --help; gpu-test runs (skipped if torch DLLs unavailable)
-split       --help: --mode, --train, --val, --seed, --prune, --watershed,
-                    --dry-run
+split       --help: --mode, --train, --val, --seed, --buffer, --prune,
+                    --watershed, --dry-run
 train       --help: --model, --mode, --device, --epochs, --imagesz,
                     --save-period, --overwrite, --resume, --no-split,
-                    --train, --val, --seed, --prune, --watershed
+                    --train, --val, --seed, --buffer, --prune, --watershed
 predict     --help: --model, --tracker, --tracker-config, --device,
                     --conf-thresh, --iou-thresh, --skip-frames,
                     --one-object-per-label, --opening-radius, --overwrite,
@@ -128,6 +128,7 @@ def test_split_help():
     assert "--train" in out
     assert "--val" in out
     assert "--seed" in out
+    assert "--buffer" in out
     assert "--prune" in out
     assert "--no-prune" in out
     assert "--watershed" in out
@@ -156,6 +157,7 @@ def test_train_help():
     assert "--train" in out
     assert "--val" in out
     assert "--seed" in out
+    assert "--buffer" in out
     assert "--prune" in out
     assert "--no-prune" in out
     assert "--watershed" in out

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -7,10 +7,11 @@ Covered subcommands and flags
 ------------------------------
 gui         --help
 gpu-test    --help; gpu-test runs (skipped if torch DLLs unavailable)
-split       --help: --mode, --train, --val, --seed, --dry-run
+split       --help: --mode, --train, --val, --seed, --prune, --watershed,
+                    --dry-run
 train       --help: --model, --mode, --device, --epochs, --imagesz,
                     --save-period, --overwrite, --resume, --no-split,
-                    --train, --val, --seed
+                    --train, --val, --seed, --prune, --watershed
 predict     --help: --model, --tracker, --tracker-config, --device,
                     --conf-thresh, --iou-thresh, --skip-frames,
                     --one-object-per-label, --opening-radius, --overwrite,
@@ -127,6 +128,10 @@ def test_split_help():
     assert "--train" in out
     assert "--val" in out
     assert "--seed" in out
+    assert "--prune" in out
+    assert "--no-prune" in out
+    assert "--watershed" in out
+    assert "--no-watershed" in out
     assert "--dry-run" in out
 
 
@@ -151,6 +156,10 @@ def test_train_help():
     assert "--train" in out
     assert "--val" in out
     assert "--seed" in out
+    assert "--prune" in out
+    assert "--no-prune" in out
+    assert "--watershed" in out
+    assert "--no-watershed" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -168,6 +168,7 @@ def test_specs_includes_model_cache_dir(cfg_path):
 def test_split_defaults(cfg_path):
     assert config.get_split_fractions() == (0.7, 0.15)
     assert config.get_split_seed() == 88
+    assert config.get_split_buffer() == 1
 
 
 def test_split_fractions_and_seed_roundtrip(cfg_path):
@@ -197,6 +198,17 @@ def test_split_set_value_rejects_negative_seed(cfg_path):
         config.set_value("split_seed", -1)
 
 
+def test_split_buffer_roundtrip(cfg_path):
+    assert config.get_split_buffer() == 1
+    config.set_value("split_buffer", 3)
+    assert config.get_split_buffer() == 3
+
+
+def test_split_set_value_rejects_negative_buffer(cfg_path):
+    with pytest.raises(ValueError):
+        config.set_value("split_buffer", -1)
+
+
 def test_split_fractions_no_test_room_falls_back(cfg_path):
     # train + val >= 1 leaves no room for a test split -> defaults.
     config.set_value("split_train_fraction", 0.7)
@@ -210,4 +222,5 @@ def test_specs_includes_split_settings(cfg_path):
         "split_train_fraction",
         "split_val_fraction",
         "split_seed",
+        "split_buffer",
     } <= keys

--- a/tests/test_unit/test_prune_utils.py
+++ b/tests/test_unit/test_prune_utils.py
@@ -1,0 +1,175 @@
+"""Tests for empty-label pruning and how it interacts with the split.
+
+Pruning happens in two stages, both gated by ``prune_empty_labels``:
+
+1. ``collect_labels`` intersects each label's annotated-frame set via
+   ``find_common_frames`` (keep only frames where *all* labels are
+   annotated).
+2. ``prepare_polygons``/``prepare_bboxes`` drop frames whose geometry came
+   out empty via ``prune_frames_by_geometry`` (cross-label intersection
+   when pruning, else per label).
+
+The pruned per-label ``frames`` then feed ``prepare_split`` /
+``train_test_val``, so pruning both shrinks the pool the fractions apply
+to and (when on) makes every label share one frame set, giving identical,
+leakage-free per-label splits.
+"""
+
+import numpy as np
+import pytest
+
+from octron.yolo_octron.helpers.training import (
+    find_common_frames,
+    prune_frames_by_geometry,
+)
+from octron.yolo_octron.yolo_octron import YOLO_octron
+
+# Any non-empty geometry value marks a frame as "valid" (a polygon/bbox
+# was produced); an empty list marks it invalid and prunable.
+_GEOM = [[(0, 0), (1, 1), (2, 0)]]
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 primitive: find_common_frames (cross-label frame intersection)
+# ---------------------------------------------------------------------------
+
+
+def test_find_common_frames_intersection():
+    a = np.arange(0, 100)
+    b = np.arange(50, 150)
+    assert list(find_common_frames([a, b])) == list(range(50, 100))
+
+
+def test_find_common_frames_single_array_unchanged():
+    a = np.array([3, 1, 2])
+    assert list(find_common_frames([a])) == [3, 1, 2]
+
+
+def test_find_common_frames_disjoint_is_empty():
+    a = np.array([0, 1, 2])
+    b = np.array([5, 6, 7])
+    assert len(find_common_frames([a, b])) == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: prune_frames_by_geometry (drop frames with empty polygons/bboxes)
+# ---------------------------------------------------------------------------
+
+
+def _labels_with_geometry(key):
+    """Two-label subfolder where each label is invalid on a different frame.
+
+    Valid A = {0, 1, 3} (frame 2 empty); valid B = {0, 2, 3} (frame 1
+    empty). Cross-label intersection is {0, 3}.
+    """
+    return {
+        "video": None,
+        "video_file_path": None,
+        0: {
+            "label": "a",
+            "frames": np.array([0, 1, 2, 3]),
+            key: {0: _GEOM, 1: _GEOM, 2: [], 3: _GEOM},
+        },
+        1: {
+            "label": "b",
+            "frames": np.array([0, 1, 2, 3]),
+            key: {0: _GEOM, 1: [], 2: _GEOM, 3: _GEOM},
+        },
+    }
+
+
+@pytest.mark.parametrize("key", ["polygons", "bboxes"])
+def test_prune_by_geometry_cross_label_intersection(key):
+    labels = _labels_with_geometry(key)
+    prune_frames_by_geometry(labels, True, key)
+    # Both labels collapse to the common valid set {0, 3}.
+    assert list(labels[0]["frames"]) == [0, 3]
+    assert list(labels[1]["frames"]) == [0, 3]
+
+
+@pytest.mark.parametrize("key", ["polygons", "bboxes"])
+def test_prune_by_geometry_per_label(key):
+    labels = _labels_with_geometry(key)
+    prune_frames_by_geometry(labels, False, key)
+    # Without pruning each label keeps its own valid frames.
+    assert list(labels[0]["frames"]) == [0, 1, 3]
+    assert list(labels[1]["frames"]) == [0, 2, 3]
+
+
+def test_prune_by_geometry_noop_when_all_valid():
+    labels = {
+        "video": None,
+        "video_file_path": None,
+        0: {
+            "label": "a",
+            "frames": np.array([0, 1]),
+            "polygons": {0: _GEOM, 1: _GEOM},
+        },
+    }
+    prune_frames_by_geometry(labels, True, "polygons")
+    assert list(labels[0]["frames"]) == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Interaction: pruning + split fractions
+# ---------------------------------------------------------------------------
+
+
+def _split_labels(label_dict):
+    """Run prepare_split on a prebuilt label_dict and return it."""
+    obj = YOLO_octron.__new__(YOLO_octron)
+    obj.label_dict = label_dict
+    obj.prepare_split(
+        training_fraction=0.7, validation_fraction=0.15, random_seed=0
+    )
+    return obj.label_dict
+
+
+def test_prune_reduces_pool_and_unifies_splits():
+    # Label A annotated on 0-799, label B only on 0-399. Stage-1 pruning
+    # intersects to 0-399, so BOTH labels split the SAME 400-frame pool:
+    # identical, leakage-free per-label splits, and the fractions apply to
+    # the reduced pool (~70/15/15).
+    common = find_common_frames([np.arange(0, 800), np.arange(0, 400)])
+    assert list(common) == list(range(400))
+
+    ld = _split_labels(
+        {
+            "sub": {
+                "video": None,
+                "video_file_path": None,
+                0: {"label": "a", "frames": common},
+                1: {"label": "b", "frames": common},
+            }
+        }
+    )
+    sa = ld["sub"][0]["frames_split"]
+    sb = ld["sub"][1]["frames_split"]
+    # Same frame -> same split for every label (no cross-label leakage).
+    for k in ("train", "val", "test"):
+        assert list(map(int, sa[k])) == list(map(int, sb[k]))
+    # Drawn only from the pruned 0-399 pool, and ~70/15/15 of it.
+    assigned = {int(x) for k in ("train", "val", "test") for x in sa[k]}
+    assert assigned <= set(range(400))
+    tot = len(assigned)
+    assert abs(len(sa["train"]) / tot - 0.70) < 0.06
+    assert abs(len(sa["val"]) / tot - 0.15) < 0.06
+    assert abs(len(sa["test"]) / tot - 0.15) < 0.06
+
+
+def test_no_prune_splits_are_independent_per_label():
+    # Without pruning, labels keep their own (different) frames and split
+    # independently, so the per-label splits differ.
+    ld = _split_labels(
+        {
+            "sub": {
+                "video": None,
+                "video_file_path": None,
+                0: {"label": "a", "frames": np.arange(0, 100)},
+                1: {"label": "b", "frames": np.arange(50, 150)},
+            }
+        }
+    )
+    sa = ld["sub"][0]["frames_split"]
+    sb = ld["sub"][1]["frames_split"]
+    assert {int(x) for x in sa["train"]} != {int(x) for x in sb["train"]}

--- a/tests/test_unit/test_prune_utils.py
+++ b/tests/test_unit/test_prune_utils.py
@@ -9,10 +9,11 @@ Pruning happens in two stages, both gated by ``prune_empty_labels``:
    out empty via ``prune_frames_by_geometry`` (cross-label intersection
    when pruning, else per label).
 
-The pruned per-label ``frames`` then feed ``prepare_split`` /
-``train_test_val``, so pruning both shrinks the pool the fractions apply
-to and (when on) makes every label share one frame set, giving identical,
-leakage-free per-label splits.
+The pruned per-label ``frames`` then feed ``prepare_split``, which decides
+the split once per frame over the union of all labels' frames -- so a
+frame shared by several labels lands in the same split for every label
+(no cross-label leakage) regardless of pruning; pruning only controls
+which frames are in the pool.
 """
 
 import numpy as np
@@ -157,9 +158,20 @@ def test_prune_reduces_pool_and_unifies_splits():
     assert abs(len(sa["test"]) / tot - 0.15) < 0.06
 
 
-def test_no_prune_splits_are_independent_per_label():
-    # Without pruning, labels keep their own (different) frames and split
-    # independently, so the per-label splits differ.
+def _frame_to_split_map(split_dict):
+    """Map each assigned frame -> its split name for one label."""
+    mapping = {}
+    for name in ("train", "val", "test"):
+        for f in split_dict[name]:
+            mapping[int(f)] = name
+    return mapping
+
+
+def test_no_prune_shared_frames_get_one_split():
+    # Without pruning, labels keep their own (different) frames, but the
+    # split is decided per FRAME over their union: a frame shared by both
+    # labels lands in the SAME split for each (no cross-label leakage),
+    # and each label's split stays within its own frames.
     ld = _split_labels(
         {
             "sub": {
@@ -170,6 +182,13 @@ def test_no_prune_splits_are_independent_per_label():
             }
         }
     )
-    sa = ld["sub"][0]["frames_split"]
-    sb = ld["sub"][1]["frames_split"]
-    assert {int(x) for x in sa["train"]} != {int(x) for x in sb["train"]}
+    ma = _frame_to_split_map(ld["sub"][0]["frames_split"])
+    mb = _frame_to_split_map(ld["sub"][1]["frames_split"])
+    # Each label's assigned frames stay within its own annotated frames.
+    assert set(ma) <= set(range(0, 100))
+    assert set(mb) <= set(range(50, 150))
+    # Frames shared by both labels get the same split in both.
+    shared = set(ma) & set(mb)
+    assert shared
+    for f in shared:
+        assert ma[f] == mb[f]

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -179,6 +179,39 @@ def test_prepare_split_seed_changes_partition():
     assert _split_with_seed(frames, 1) != _split_with_seed(frames, 2)
 
 
+def _assigned_count_with_buffer(frames, buffer):
+    """Run prepare_split on a one-label fixture; count assigned frames."""
+    obj = YOLO_octron.__new__(YOLO_octron)
+    obj.label_dict = {
+        "sub": {
+            "video": None,
+            "video_file_path": None,
+            0: {"label": "a", "frames": np.array(frames)},
+        }
+    }
+    obj.prepare_split(
+        training_fraction=0.6,
+        validation_fraction=0.2,
+        random_seed=0,
+        buffer=buffer,
+    )
+    s = obj.label_dict["sub"][0]["frames_split"]
+    return sum(len(s[k]) for k in ("train", "val", "test"))
+
+
+def test_prepare_split_forwards_buffer():
+    """prepare_split threads buffer through to train_test_val.
+
+    buffer=0 keeps every frame (a single contiguous episode assigns all
+    frames to some split); buffer>0 drops frames at block boundaries, so
+    the assigned set shrinks. Regression: prepare_split used to ignore
+    buffer and always use train_test_val's default.
+    """
+    frames = list(range(200))
+    assert _assigned_count_with_buffer(frames, 0) == 200
+    assert _assigned_count_with_buffer(frames, 1) < 200
+
+
 # ---------------------------------------------------------------------------
 # train_test_val: contiguous-block split behaviour
 # ---------------------------------------------------------------------------

--- a/tests/test_unit/test_split_utils.py
+++ b/tests/test_unit/test_split_utils.py
@@ -95,6 +95,55 @@ def test_run_split_accepts_valid_fractions():
     assert "fraction" not in str(exc.value).lower()
 
 
+def test_run_split_threads_prune_and_watershed(monkeypatch):
+    """run_split forwards prune/watershed to prepare_labels/enable_watershed.
+
+    Regression for the CLI/GUI parity gap (#90): run_split used to call
+    prepare_labels() with no args (always pruning) and never set
+    enable_watershed, so headless runs silently differed from the GUI.
+    """
+    recorded = {}
+    instances = []
+
+    class _FakeYolo:
+        def __init__(self, **kwargs):
+            self.train_mode = None
+            self.enable_watershed = None
+            self.label_dict = {}
+            instances.append(self)
+
+        @staticmethod
+        def _validate_split_fractions(train, val):
+            return None
+
+        def prepare_labels(self, prune_empty_labels=True, **kwargs):
+            recorded["prune"] = prune_empty_labels
+
+        def prepare_geometry(self):
+            return iter(())
+
+        def prepare_split(self, **kwargs):
+            pass
+
+        def summarize_split(self):
+            return []
+
+    monkeypatch.setattr(
+        "octron.yolo_octron.yolo_octron.YOLO_octron", _FakeYolo
+    )
+    run_split(
+        project_path="/nope_for_test",
+        train_fraction=0.7,
+        val_fraction=0.15,
+        seed=0,
+        prune=True,
+        watershed=True,
+        dry_run=True,
+    )
+    assert recorded["prune"] is True
+    assert instances[0].enable_watershed is True
+
+
 # ---------------------------------------------------------------------------
 # prepare_split threads the seed through to train_test_val
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a subtle issue where, in multi-label projects, a single video frame could end up in two different splits at once. It also brings OCTRON's command-line (CLI) training tools in line with the graphical interface when preparing training data. From the CLI you can now control whether incomplete frames are pruned, whether touching objects are separated (watershed), and how big a gap to leave between training and validation/test frames — with defaults living in the same `config.yaml` the GUI already uses. 

## Technical summary
- `octron split`/`octron train` gain `--prune/--no-prune`, `--watershed/--no-watershed`, and `--buffer`, matching the GUI checkboxes (the CLI previously always pruned).
- New `split_buffer` config key joins `split_train_fraction`/`split_val_fraction`/`split_seed`; precedence is CLI flag > `config.yaml` > built-in default, and the GUI reads the same values.
- `prepare_split` computes the train/val/test assignment once over the union of every label's frames and filters it per label, so a frame shared across classes can't leak into different splits (previously this duplicated images across split folders with incomplete `.txt` labels).
- Shared empty-geometry pruning is extracted into `prune_frames_by_geometry`; new unit tests cover the CLI flags, the config, per-frame split consistency, and buffer forwarding.
- Validation: ruff + all pre-commit hooks pass; 208 tests pass.

Closes #90

Co-Authored-By: Oz <oz-agent@warp.dev>