### PR TITLE
CLI: config modification

### DIFF
--- a/octron/cli.py
+++ b/octron/cli.py
@@ -6,7 +6,8 @@ Subcommands
 -----------
   gui         Launch the OCTRON napari GUI
   gpu-test    Check GPU availability
-  config      View/edit config.yaml settings (list/get/set/path/edit)
+  config      View/edit config.yaml settings
+              (init/list/get/set/path/edit)
   split       Prepare and export train/val/test data from an OCTRON project
   train       Prepare training data and run YOLO model training
   predict     Run YOLO prediction and tracking on one or more videos
@@ -1066,6 +1067,30 @@ def _fmt_setting(value) -> str:
     return "(unset)" if value is None or value == "" else str(value)
 
 
+@config_app.command("init")
+def config_init(
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite an existing config.yaml."
+    ),
+):
+    """Write a commented config.yaml template (all settings + defaults).
+
+    The template is fully commented, so it documents every setting
+    without changing any built-in default until you uncomment a line.
+    """
+    from octron import config
+
+    path = config.write_template(force=force)
+    if path is None:
+        existing = config.config_path().as_posix()
+        logger.info(
+            f"config.yaml already exists at {existing}; "
+            f"use --force to overwrite."
+        )
+        return
+    logger.info(f"Wrote config template to {path.as_posix()}")
+
+
 @config_app.command("list")
 def config_list():
     """List every setting with its value, default, source and help."""
@@ -1155,8 +1180,7 @@ def config_edit():
 
     path = config.config_path()
     if not path.exists():
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("# OCTRON user configuration\n")
+        config.write_template()
     click.edit(filename=str(path))
 
 

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -6,6 +6,7 @@ Subcommands
 -----------
   gui         Launch the OCTRON napari GUI
   gpu-test    Check GPU availability
+  config      View/edit config.yaml settings (list/get/set/path/edit)
   split       Prepare and export train/val/test data from an OCTRON project
   train       Prepare training data and run YOLO model training
   predict     Run YOLO prediction and tracking on one or more videos
@@ -1043,6 +1044,117 @@ def download_sam3(
         f"SAM checkpoints are in: "
         f"{config.get_sam_checkpoints_dir().as_posix()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# config: view and edit config.yaml settings
+# ---------------------------------------------------------------------------
+
+config_app = typer.Typer(
+    name="config",
+    help="View and edit OCTRON settings stored in config.yaml.",
+    no_args_is_help=True,
+)
+app.add_typer(config_app, name="config")
+
+
+def _fmt_setting(value) -> str:
+    """Format a setting value for display (``None``/'' -> ``(unset)``)."""
+    return "(unset)" if value is None or value == "" else str(value)
+
+
+@config_app.command("list")
+def config_list():
+    """List every setting with its value, default, source and help."""
+    import textwrap
+
+    from octron import config
+
+    effective = config.load()
+    from_file = config.user_keys()
+    path = config.config_path()
+    suffix = "" if path.exists() else "  (not created yet)"
+    typer.echo(f"config.yaml: {path.as_posix()}{suffix}")
+    typer.echo("")
+    for spec in config.specs():
+        source = "config.yaml" if spec.key in from_file else "default"
+        typer.echo(
+            f"{spec.key} = {_fmt_setting(effective[spec.key])}"
+            f"   [default: {_fmt_setting(spec.default)}, source: {source}]"
+        )
+        for line in textwrap.wrap(spec.description, width=72):
+            typer.echo(f"    {line}")
+        typer.echo("")
+
+
+@config_app.command("get")
+def config_get(
+    key: str = typer.Argument(
+        ..., help="Setting name (see 'octron config list')."
+    ),
+):
+    """Print the effective value of KEY to stdout (only the value).
+
+    Handy in scripts, e.g. ``SEED=$(octron config get split_seed)``.
+    """
+    from octron import config
+
+    try:
+        value = config.get_value(key)
+    except KeyError as e:
+        raise typer.BadParameter(
+            f"unknown setting {key!r}; see 'octron config list'.",
+            param_hint="KEY",
+        ) from e
+    typer.echo("" if value is None else str(value))
+
+
+@config_app.command("set")
+def config_set(
+    key: str = typer.Argument(
+        ..., help="Setting name (see 'octron config list')."
+    ),
+    value: str = typer.Argument(
+        ..., help="New value; use '' to clear a directory setting."
+    ),
+):
+    """Validate VALUE and save it to config.yaml (creating it if needed)."""
+    from octron import config
+
+    try:
+        path = config.set_value(key, value)
+    except KeyError as e:
+        raise typer.BadParameter(
+            f"unknown setting {key!r}; see 'octron config list'.",
+            param_hint="KEY",
+        ) from e
+    except (ValueError, TypeError) as e:
+        raise typer.BadParameter(str(e), param_hint="VALUE") from e
+    logger.info(f"Set {key} = {config.get_value(key)!r} in {path.as_posix()}")
+
+
+@config_app.command("path")
+def config_show_path():
+    """Print the config.yaml location and whether it exists yet."""
+    from octron import config
+
+    path = config.config_path()
+    state = "exists" if path.exists() else "not created yet"
+    typer.echo(f"{path.as_posix()} ({state})")
+
+
+@config_app.command("edit")
+def config_edit():
+    """Open config.yaml in your $EDITOR (creating it if missing)."""
+    import click
+
+    from octron import config
+
+    path = config.config_path()
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# OCTRON user configuration\n")
+    click.edit(filename=str(path))
 
 
 def main():

--- a/octron/cli.py
+++ b/octron/cli.py
@@ -333,7 +333,9 @@ def train(
     train_mode: TrainMode = typer.Option(
         TrainMode.segment, "--mode", help="Training mode."
     ),
-    device: Device = typer.Option(Device.auto, help="Device to train on."),
+    device: Device | None = typer.Option(
+        None, help="Device to train on (default: config.yaml)."
+    ),
     epochs: int = typer.Option(250, help="Number of training epochs."),
     imagesz: int = typer.Option(640, help="Input image size."),
     save_period: int = typer.Option(
@@ -449,8 +451,8 @@ def predict(
         "--tracker-config",
         help="Path to a custom tracker config YAML (overrides --tracker).",
     ),
-    device: Device = typer.Option(
-        Device.auto, help="Device to run inference on."
+    device: Device | None = typer.Option(
+        None, help="Device to run inference on (default: config.yaml)."
     ),
     conf_thresh: float = typer.Option(
         0.5, help="Confidence threshold for detection."
@@ -476,8 +478,9 @@ def predict(
     detailed: str | None = typer.Option(
         None, "--detailed", help=_DETAILED_HELP
     ),
-    buffer_size: int = typer.Option(
-        500, help="Frame buffer size before writing to zarr."
+    buffer_size: int | None = typer.Option(
+        None,
+        help="Frames buffered before writing to zarr (default: config.yaml).",
     ),
     output_dir: Path | None = typer.Option(
         None,

--- a/octron/config.py
+++ b/octron/config.py
@@ -40,6 +40,7 @@ Example ``config.yaml``::
 """
 
 import os
+import textwrap
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -366,6 +367,58 @@ def set_value(key: str, value) -> Path:
     with open(path, "w") as f:
         f.write("# OCTRON user configuration\n")
         yaml.safe_dump(data, f, default_flow_style=False, sort_keys=True)
+    return path
+
+
+def _yaml_scalar(value) -> str:
+    """Render a default as a simple YAML scalar for the config template."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def render_template() -> str:
+    """Return a fully commented ``config.yaml`` template.
+
+    Every setting is emitted as commented-out lines (its description,
+    allowed choices where relevant, and its built-in default), so the
+    file documents the available settings and is ready to edit. It is
+    inert: an untouched template reads as an empty mapping, so all
+    built-in defaults still apply until a line is uncommented.
+    """
+    lines = [
+        "# OCTRON user configuration",
+        "#",
+        "# Uncomment and edit a line below to override the built-in default.",
+        "# Delete this file to fall back to all built-in defaults.",
+        "",
+    ]
+    for spec in SETTINGS:
+        for wrapped in textwrap.wrap(spec.description, width=74):
+            lines.append(f"# {wrapped}")
+        if spec.choices:
+            lines.append(
+                f"#   choices: {', '.join(str(c) for c in spec.choices)}"
+            )
+        lines.append(f"# {spec.key}: {_yaml_scalar(spec.default)}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def write_template(force: bool = False) -> Path | None:
+    """Write the commented template (see :func:`render_template`) to disk.
+
+    Writes to :func:`config_path`. Returns the written path, or None when
+    the file already exists and ``force`` is False (nothing is
+    overwritten). Parent directories are created as needed.
+    """
+    path = config_path()
+    if path.exists() and not force:
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_template())
     return path
 
 

--- a/octron/config.py
+++ b/octron/config.py
@@ -290,6 +290,15 @@ def specs() -> "tuple[SettingSpec, ...]":
     return SETTINGS
 
 
+def user_keys() -> set:
+    """Return known setting keys explicitly stored in ``config.yaml``.
+
+    Keys absent from the file (served from their in-code default) are not
+    included. Used by ``octron config list`` to show each value's source.
+    """
+    return {key for key in _read_raw() if key in _SPECS}
+
+
 # ---------------------------------------------------------------------------
 # Write
 # ---------------------------------------------------------------------------

--- a/octron/config.py
+++ b/octron/config.py
@@ -119,6 +119,26 @@ def _coerce_nonneg_int(value):
     return number
 
 
+def _coerce_positive_int(value):
+    """Coerce a value to a positive integer (>= 1)."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError("expected an integer") from e
+    if number < 1:
+        raise ValueError("must be >= 1")
+    return number
+
+
+def _coerce_device(value):
+    """Coerce a compute-device setting to one of auto/cpu/cuda/mps."""
+    text = str(value).strip().lower()
+    allowed = ("auto", "cpu", "cuda", "mps")
+    if text not in allowed:
+        raise ValueError(f"must be one of {', '.join(allowed)}")
+    return text
+
+
 # The settings schema.  Add new user settings here; everything else (loading,
 # validation, the CLI, and a settings dialog) picks them up automatically.
 SETTINGS: "tuple[SettingSpec, ...]" = (
@@ -188,6 +208,30 @@ SETTINGS: "tuple[SettingSpec, ...]" = (
             "is omitted, and by the GUI."
         ),
         coerce=_coerce_nonneg_int,
+    ),
+    SettingSpec(
+        key="device",
+        default="auto",
+        kind="choice",
+        choices=("auto", "cpu", "cuda", "mps"),
+        description=(
+            "Compute device for training and prediction: 'auto' picks "
+            "CUDA, then MPS, then CPU. Set 'cpu'/'cuda'/'mps' to force "
+            "one. The GUI has no device selector, so this is the only "
+            "way to override auto-detection there."
+        ),
+        coerce=_coerce_device,
+    ),
+    SettingSpec(
+        key="prediction_buffer_size",
+        default=500,
+        kind="int",
+        description=(
+            "Frames buffered before writing prediction output to zarr. "
+            "Lower it to reduce memory use on constrained machines. Used "
+            "when --buffer-size is omitted, and by the GUI."
+        ),
+        coerce=_coerce_positive_int,
     ),
 )
 
@@ -420,3 +464,13 @@ def get_split_seed() -> int:
 def get_split_buffer() -> int:
     """Return the buffer (frames dropped at split block boundaries)."""
     return get_value("split_buffer")
+
+
+def get_device() -> str:
+    """Return the configured compute device ('auto'/'cpu'/'cuda'/'mps')."""
+    return get_value("device")
+
+
+def get_prediction_buffer_size() -> int:
+    """Return the zarr write buffer size (frames) used during prediction."""
+    return get_value("prediction_buffer_size")

--- a/octron/main.py
+++ b/octron/main.py
@@ -2338,6 +2338,19 @@ def octron_gui():
 
     setup_logging()
 
+    # Create a commented config.yaml template on first launch so the
+    # settings are discoverable and editable. No-op if the file already
+    # exists; the template is inert (all comments) until a line is
+    # uncommented, so it never overrides a built-in default.
+    from octron import config
+
+    try:
+        _written = config.write_template()
+        if _written is not None:
+            logger.info(f"Created config template at {_written.as_posix()}")
+    except Exception as e:  # never let config priming block startup
+        logger.debug(f"Could not create config template: {e}")
+
     # Give OCTRON its own Windows taskbar identity, then (on Windows)
     # create the QApplication ourselves *before* napari does.
     _set_windows_app_id()

--- a/octron/tools/predict.py
+++ b/octron/tools/predict.py
@@ -21,14 +21,14 @@ def run_predict(
     tracker_name=None,
     tracker_cfg_path=None,
     tracker_params=None,
-    device="auto",
+    device=None,
     conf_thresh=0.5,
     iou_thresh=0.7,
     skip_frames=0,
     one_object_per_label=False,
     opening_radius=0,
     overwrite=False,
-    buffer_size=500,
+    buffer_size=None,
     region_properties=None,
     output_dir=None,
     debug=False,
@@ -50,9 +50,10 @@ def run_predict(
         ``tracker_name``).
     tracker_params : dict, optional
         Parameter overrides applied on top of the resolved tracker config.
-    device : str
-        Device to run inference on ('auto', 'cpu', 'cuda', 'mps'). 'auto'
-        selects CUDA if available, then MPS, then CPU.
+    device : str or None
+        Device to run inference on ('auto', 'cpu', 'cuda', 'mps'). None
+        reads ``device`` from ``config.yaml`` (default 'auto' selects CUDA
+        if available, then MPS, then CPU).
     conf_thresh : float
         Confidence threshold for detection.
     iou_thresh : float
@@ -65,8 +66,9 @@ def run_predict(
         Morphological opening radius applied to masks to remove noise.
     overwrite : bool
         Overwrite existing prediction results.
-    buffer_size : int
-        Number of frames buffered before writing to zarr.
+    buffer_size : int or None
+        Number of frames buffered before writing to zarr. None reads
+        ``prediction_buffer_size`` from ``config.yaml``.
     region_properties : tuple or None
         Region property names to extract via skimage.measure.regionprops_table.
         Pass DEFAULT_REGION_PROPERTIES for the standard set, or None to skip.
@@ -117,11 +119,20 @@ def run_predict(
 
     from loguru import logger
 
+    from octron import config
     from octron.test_gpu import auto_device
     from octron.yolo_octron.yolo_octron import YOLO_octron
 
     # Silence boxmot's verbose INFO chatter (tracker init parameter dumps).
     logger.disable("boxmot")
+
+    # Resolve device/buffer_size from config.yaml when not set explicitly
+    # (the CLI passes None). Precedence: explicit arg > config.yaml >
+    # built-in default.
+    if device is None:
+        device = config.get_device()
+    if buffer_size is None:
+        buffer_size = config.get_prediction_buffer_size()
 
     # Unwrap a Device enum to its plain string value (mirrors run_training).
     # boxmot's select_device() calls str(device).lower(); a (str, Enum)

--- a/octron/tools/split.py
+++ b/octron/tools/split.py
@@ -37,18 +37,18 @@ def run_split(
     project_path : str or Path
         Path to the OCTRON project directory.
     train_fraction : float or None
-        Fraction of frames for the training split. ``None`` (the CLI
+        Fraction of frames for the training split. None (the CLI
         default) reads ``split_train_fraction`` from ``config.yaml``.
     val_fraction : float or None
         Fraction of frames for the validation split; the remainder
-        becomes the test split. ``None`` reads ``split_val_fraction``
+        becomes the test split. None reads ``split_val_fraction``
         from config.
     seed : int or None
-        Random seed for reproducibility. ``None`` reads ``split_seed``
+        Random seed for reproducibility. None reads ``split_seed``
         from config.
     buffer : int or None
         Frames dropped at each train/val/test block boundary to add a
-        temporal gap between splits. ``None`` (the CLI default) reads
+        temporal gap between splits. None (the CLI default) reads
         ``split_buffer`` from ``config.yaml``.
     prune : bool
         Drop frames where not all labels are annotated (threaded to

--- a/octron/tools/train.py
+++ b/octron/tools/train.py
@@ -16,7 +16,7 @@ def run_training(
     project_path,
     model="YOLO26m",
     train_mode="segment",
-    device="auto",
+    device=None,
     epochs=250,
     imagesz=640,
     save_period=50,
@@ -41,9 +41,10 @@ def run_training(
         Path to the OCTRON project directory.
     model : str or Path
         YOLO model name (e.g. 'YOLO11m') or path to an existing model file.
-    device : str
-        Device to train on ('auto', 'cpu', 'cuda', 'mps'). 'auto' selects
-        CUDA if available, then MPS, then CPU.
+    device : str or None
+        Device to train on ('auto', 'cpu', 'cuda', 'mps'). None reads
+        ``device`` from ``config.yaml`` (default 'auto' selects CUDA if
+        available, then MPS, then CPU).
     epochs : int
         Number of training epochs.
     imagesz : int
@@ -62,16 +63,16 @@ def run_training(
         Skip data preparation. Use when ``octron split`` has already been run
         and the training data is up to date.
     train_fraction : float or None
-        Fraction of frames for training. ``None`` reads ``config.yaml``
+        Fraction of frames for training. None reads ``config.yaml``
         (ignored when ``skip_split=True``).
     val_fraction : float or None
-        Fraction of frames for validation. ``None`` reads ``config.yaml``
+        Fraction of frames for validation. None reads ``config.yaml``
         (ignored when ``skip_split=True``).
     seed : int or None
-        Random seed for the split. ``None`` reads ``config.yaml``
+        Random seed for the split. None reads ``config.yaml``
         (ignored when ``skip_split=True``).
     buffer : int or None
-        Frames dropped at each train/val/test block boundary. ``None``
+        Frames dropped at each train/val/test block boundary. None
         reads ``config.yaml`` (ignored when ``skip_split=True``).
     prune : bool
         Drop frames where not all labels are annotated (ignored when
@@ -81,6 +82,7 @@ def run_training(
         (ignored when ``skip_split=True``). Default ``False``.
 
     """
+    from octron import config
     from octron.test_gpu import auto_device
     from octron.tools.split import run_split
     from octron.yolo_octron.yolo_octron import YOLO_octron
@@ -90,6 +92,10 @@ def run_training(
     train_mode = (
         train_mode.value if hasattr(train_mode, "value") else str(train_mode)
     )
+    # Resolve device from config.yaml when not set explicitly (the CLI
+    # passes None). Precedence: explicit arg > config.yaml > 'auto'.
+    if device is None:
+        device = config.get_device()
     device = device.value if hasattr(device, "value") else str(device)
 
     if device == "auto":

--- a/octron/yolo_octron/gui/yolo_handler.py
+++ b/octron/yolo_octron/gui/yolo_handler.py
@@ -4,7 +4,6 @@ import shutil
 import time
 from pathlib import Path
 
-import torch
 import yaml
 from loguru import logger
 from napari.qt import create_worker
@@ -47,15 +46,16 @@ class YoloHandler(QObject):
         self.w = parent_widget  # main.py -> octron_widget
         self.yolo = yolo_octron
 
-        # Device label?
-        if torch.cuda.is_available():
-            self.device_label = "cuda"  # torch.device("cuda")
-        elif torch.backends.mps.is_available():
-            self.device_label = "mps"  # "mps" # torch.device("mps")
-            # print(f'MPS is available, but not yet supported.
-            # Using CPU instead.')
-        else:
-            self.device_label = "cpu"  # torch.device("cpu")
+        # Device: use the configured device from config.yaml ('device').
+        # 'auto' auto-detects cuda -> mps -> cpu. This is the only way a
+        # GUI user can override the device, since there is no device widget.
+        from octron import config
+        from octron.test_gpu import auto_device
+
+        configured_device = config.get_device()
+        self.device_label = (
+            auto_device() if configured_device == "auto" else configured_device
+        )
         logger.info(f'Using YOLO device: "{self.device_label}"')
 
         # Set up variables
@@ -1345,6 +1345,8 @@ class YoloHandler(QObject):
 
         # Call the prediction function which yields progress info
         # self.videos_to_predict is a dict: {video_name: video_metadata_dict}
+        from octron import config
+
         yield from self.yolo.predict_batch(
             videos=self.videos_to_predict,
             model_path=self.model_predict_path,
@@ -1357,6 +1359,7 @@ class YoloHandler(QObject):
             conf_thresh=self.conf_thresh,
             opening_radius=self.mask_opening,
             overwrite=self.overwrite_predictions,
+            buffer_size=config.get_prediction_buffer_size(),
         )
 
     def _update_prediction_progress(self, progress_info):

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -174,8 +174,36 @@ def test_config_help():
     result = runner.invoke(app, ["config", "--help"])
     assert result.exit_code == 0
     out = _plain(result.output)
-    for sub in ("list", "get", "set", "path", "edit"):
+    for sub in ("init", "list", "get", "set", "path", "edit"):
         assert sub in out
+
+
+def test_config_init_creates_and_respects_force(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    env = {"OCTRON_CONFIG_PATH": str(cfg)}
+    assert runner.invoke(app, ["config", "init"], env=env).exit_code == 0
+    assert cfg.exists()
+    # The template is inert: split_seed still reports the default.
+    assert (
+        "88"
+        in runner.invoke(app, ["config", "get", "split_seed"], env=env).output
+    )
+    # A user override survives a plain re-init (no overwrite)...
+    runner.invoke(app, ["config", "set", "split_seed", "7"], env=env)
+    assert runner.invoke(app, ["config", "init"], env=env).exit_code == 0
+    assert (
+        "7"
+        in runner.invoke(app, ["config", "get", "split_seed"], env=env).output
+    )
+    # ...but --force overwrites back to the template (default again).
+    assert (
+        runner.invoke(app, ["config", "init", "--force"], env=env).exit_code
+        == 0
+    )
+    assert (
+        "88"
+        in runner.invoke(app, ["config", "get", "split_seed"], env=env).output
+    )
 
 
 def test_config_path_reports_location(tmp_path):

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -7,6 +7,7 @@ Covered subcommands and flags
 ------------------------------
 gui         --help
 gpu-test    --help; gpu-test runs (skipped if torch DLLs unavailable)
+config      --help + list/get/set/path (get/set/path use OCTRON_CONFIG_PATH)
 split       --help: --mode, --train, --val, --seed, --buffer, --prune,
                     --watershed, --dry-run
 train       --help: --model, --mode, --device, --epochs, --imagesz,
@@ -162,6 +163,75 @@ def test_train_help():
     assert "--no-prune" in out
     assert "--watershed" in out
     assert "--no-watershed" in out
+
+
+# ---------------------------------------------------------------------------
+# config
+# ---------------------------------------------------------------------------
+
+
+def test_config_help():
+    result = runner.invoke(app, ["config", "--help"])
+    assert result.exit_code == 0
+    out = _plain(result.output)
+    for sub in ("list", "get", "set", "path", "edit"):
+        assert sub in out
+
+
+def test_config_path_reports_location(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    result = runner.invoke(
+        app, ["config", "path"], env={"OCTRON_CONFIG_PATH": str(cfg)}
+    )
+    assert result.exit_code == 0
+    assert str(cfg) in result.output
+    assert "not created yet" in result.output
+
+
+def test_config_set_and_get_roundtrip(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    env = {"OCTRON_CONFIG_PATH": str(cfg)}
+    set_result = runner.invoke(
+        app, ["config", "set", "split_seed", "4242"], env=env
+    )
+    assert set_result.exit_code == 0
+    assert cfg.exists()
+    get_result = runner.invoke(app, ["config", "get", "split_seed"], env=env)
+    assert get_result.exit_code == 0
+    assert "4242" in get_result.output
+
+
+def test_config_get_unknown_key_errors(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    result = runner.invoke(
+        app,
+        ["config", "get", "not_a_key"],
+        env={"OCTRON_CONFIG_PATH": str(cfg)},
+    )
+    assert result.exit_code != 0
+    assert "unknown setting" in _plain(result.output).lower()
+
+
+def test_config_set_invalid_value_errors(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    result = runner.invoke(
+        app,
+        ["config", "set", "split_val_fraction", "1.5"],
+        env={"OCTRON_CONFIG_PATH": str(cfg)},
+    )
+    assert result.exit_code != 0
+
+
+def test_config_list_shows_settings_and_source(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    result = runner.invoke(
+        app, ["config", "list"], env={"OCTRON_CONFIG_PATH": str(cfg)}
+    )
+    assert result.exit_code == 0
+    out = _plain(result.output)
+    assert "split_seed" in out
+    assert "prediction_cache_dir" in out
+    assert "source: default" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unit/test_cli.py
+++ b/tests/test_unit/test_cli.py
@@ -184,7 +184,10 @@ def test_config_path_reports_location(tmp_path):
         app, ["config", "path"], env={"OCTRON_CONFIG_PATH": str(cfg)}
     )
     assert result.exit_code == 0
-    assert str(cfg) in result.output
+    # The CLI prints paths via Path.as_posix() (forward slashes on every
+    # OS), so compare against that rather than str(cfg), which uses
+    # backslashes on Windows.
+    assert cfg.as_posix() in result.output
     assert "not created yet" in result.output
 
 

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -268,3 +268,44 @@ def test_user_keys_reports_only_file_keys(cfg_path):
     assert config.user_keys() == set()
     config.set_value("split_seed", 7)
     assert config.user_keys() == {"split_seed"}
+
+
+# ---------------------------------------------------------------------------
+# config.yaml template (octron config init / GUI first-launch priming)
+# ---------------------------------------------------------------------------
+
+
+def test_render_template_documents_all_settings(cfg_path):
+    text = config.render_template()
+    for spec in config.specs():
+        # Each setting appears as a commented-out key line.
+        assert f"# {spec.key}:" in text
+
+
+def test_template_is_inert(cfg_path):
+    # A freshly written template overrides nothing: reading it yields the
+    # built-in defaults and reports no user-set keys.
+    cfg_path.write_text(config.render_template())
+    assert config.user_keys() == set()
+    assert config.load() == {s.key: s.default for s in config.specs()}
+
+
+def test_write_template_creates_when_absent(cfg_path):
+    assert not cfg_path.exists()
+    written = config.write_template()
+    assert written == cfg_path
+    assert cfg_path.exists()
+
+
+def test_write_template_skips_existing_without_force(cfg_path):
+    config.set_value("split_seed", 7)  # creates the file with an override
+    assert config.write_template() is None
+    assert config.get_split_seed() == 7  # untouched
+
+
+def test_write_template_force_overwrites(cfg_path):
+    config.set_value("split_seed", 7)
+    written = config.write_template(force=True)
+    assert written == cfg_path
+    # Overwritten with the inert template -> back to the default.
+    assert config.get_split_seed() == 88

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -226,6 +226,43 @@ def test_specs_includes_split_settings(cfg_path):
     } <= keys
 
 
+# ---------------------------------------------------------------------------
+# Device + prediction buffer size
+# ---------------------------------------------------------------------------
+
+
+def test_device_default_and_roundtrip(cfg_path):
+    assert config.get_device() == "auto"
+    config.set_value("device", "cpu")
+    assert config.get_device() == "cpu"
+
+
+def test_device_normalizes_case(cfg_path):
+    config.set_value("device", "CUDA")
+    assert config.get_device() == "cuda"
+
+
+def test_device_rejects_unknown(cfg_path):
+    with pytest.raises(ValueError):
+        config.set_value("device", "gpu")
+
+
+def test_prediction_buffer_size_default_and_roundtrip(cfg_path):
+    assert config.get_prediction_buffer_size() == 500
+    config.set_value("prediction_buffer_size", 250)
+    assert config.get_prediction_buffer_size() == 250
+
+
+def test_prediction_buffer_size_rejects_non_positive(cfg_path):
+    with pytest.raises(ValueError):
+        config.set_value("prediction_buffer_size", 0)
+
+
+def test_specs_includes_device_and_buffer(cfg_path):
+    keys = {s.key for s in config.specs()}
+    assert {"device", "prediction_buffer_size"} <= keys
+
+
 def test_user_keys_reports_only_file_keys(cfg_path):
     # user_keys() reflects only what's stored in config.yaml, not defaults.
     assert config.user_keys() == set()

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -224,3 +224,10 @@ def test_specs_includes_split_settings(cfg_path):
         "split_seed",
         "split_buffer",
     } <= keys
+
+
+def test_user_keys_reports_only_file_keys(cfg_path):
+    # user_keys() reflects only what's stored in config.yaml, not defaults.
+    assert config.user_keys() == set()
+    config.set_value("split_seed", 7)
+    assert config.user_keys() == {"split_seed"}


### PR DESCRIPTION
Introduces new command line interface (CLI) argument "config", which lets users edit / see the config.yaml, i.e. global arguments that are saved in that file. 
The purpose of the config.yaml is to capture high level paths, for example the model download path, and those arguments that are not editable through the GUI, and thus revert to a default inaccessible to the user. Note that most of these ARE callable through the CLI already, just not exposed in the GUI. 